### PR TITLE
fix: remove gradle-semantic-release-plugin from semantic-release config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "eslint-plugin-react-hooks": "^6.1.1",
         "eslint-plugin-storybook": "^9.1.13",
         "glob": "^11",
-        "gradle-semantic-release-plugin": "^1.10.1",
         "husky": "^9.1.7",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.0.5",
@@ -16263,29 +16262,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/gradle-semantic-release-plugin": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/gradle-semantic-release-plugin/-/gradle-semantic-release-plugin-1.10.1.tgz",
-      "integrity": "sha512-Q4dLAFICjPouUyRRHEKK8cXNB75nraXoioYZDZlVQOg4sYKudnTDZ3ohLmV3k4cPGiiMCh1ckXETkx9JnuyKmA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/KengoTODA"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "promisified-properties": "^3.0.0",
-        "split2": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "semantic-release": "^24.0.0"
-      }
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -23814,13 +23790,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/parsimmon": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
-      "integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -24686,20 +24655,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/promisified-properties": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/promisified-properties/-/promisified-properties-3.0.0.tgz",
-      "integrity": "sha512-ARteuBuUpPg/+spsMhcKHvdtOW/q8btyyVYYxxegGgx+7u9ix9at8DjP2KM2t8+4SuI8wBLt+3X876FMQx91yQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parsimmon": "^1.13.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=7.12"
-      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "eslint-plugin-react-hooks": "^6.1.1",
     "eslint-plugin-storybook": "^9.1.13",
     "glob": "^11",
-    "gradle-semantic-release-plugin": "^1.10.1",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.0.5",
@@ -177,11 +176,10 @@
           "npmPublish": false
         }
       ],
-      "gradle-semantic-release-plugin",
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "./gradlew clean build -Penv=prod",
+          "prepareCmd": "sed -i \"s/^version = .*/version = ${nextRelease.version}/\" gradle.properties && ./gradlew clean build -Penv=prod",
           "publishCmd": "enonic app install --file build/libs/Liberalistene.jar"
         }
       ],


### PR DESCRIPTION
## Summary

Fixes the release workflow failure by removing the problematic `gradle-semantic-release-plugin`.

## Problem

The release workflow was failing with:
```
Error: No task found that can publish artifacts
```

The `gradle-semantic-release-plugin` expects a Gradle `publish` task for publishing to Maven repositories. This project doesn't have or need a publish task, as deployment is handled by the Enonic CLI.

## Solution

- ✅ Removed `gradle-semantic-release-plugin` from plugins array
- ✅ Updated `@semantic-release/exec` prepareCmd to update `gradle.properties` version using `sed`
- ✅ Version update functionality preserved, just moved to exec plugin
- ✅ `@semantic-release/git` still commits `gradle.properties` as part of the release

## Changes

**package.json:**
- Removed: `"gradle-semantic-release-plugin"`
- Updated: `prepareCmd` now includes version update via `sed`

## Testing

This fix will allow the release workflow to complete successfully when merged to master.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>