### PR TITLE
chore: upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Claude Review Dependabot PR
         uses: grll/claude-code-action@beta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.15.1'
           cache: 'npm'
@@ -31,7 +31,7 @@ jobs:
         run: npm run build-storybook
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static


### PR DESCRIPTION
## Summary

Consolidates 4 Dependabot PRs into a single upgrade of all GitHub Actions to their latest versions.

## Changes

### GitHub Actions Upgraded

- ✅ **actions/checkout**: v4 → v5
- ✅ **actions/setup-node**: v4 → v6
- ✅ **actions/setup-java**: v4 → v5
- ✅ **peaceiris/actions-gh-pages**: v3 → v4

### Files Modified

- `.github/workflows/ci.yml`
- `.github/workflows/claude-dependabot.yml`
- `.github/workflows/release.yml`
- `.github/workflows/storybook.yml`

## Testing

All 4 original Dependabot PRs passed CI tests:
- ✅ Test suite passed on all PRs
- ✅ No breaking changes in these official GitHub Actions updates
- ✅ Standard version upgrades with improved performance and security

## Consolidates PRs

This PR replaces and consolidates:
- PR #65 - actions/checkout v5
- PR #66 - actions/setup-java v5
- PR #67 - actions/setup-node v6
- PR #69 - peaceiris/actions-gh-pages v4

Once this PR is merged, the 4 Dependabot PRs can be closed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>