### PR TITLE
fix: anchor banner images to top to prevent heads being cropped

### DIFF
--- a/src/assets/tailwind/components/imageblock.css
+++ b/src/assets/tailwind/components/imageblock.css
@@ -30,7 +30,7 @@
   }
 
   .image-block .full > img {
-    @apply w-full object-cover h-full;
+    @apply w-full object-cover h-full object-top;
   }
 
   .image-block > .content {


### PR DESCRIPTION
## Summary

Fixes banner image positioning issue where people's heads were getting cut off in hero/ImageBlock components.

## Problem

The ImageBlock component uses `object-cover` to fill the 458px height container with background images. Without an explicit `object-position`, images default to centering vertically, which crops equally from top and bottom. This caused people's heads to be cut off when images were taller than the container.

## Solution

Added `object-top` to anchor images to the top of the container. Now when images need to be cropped, they crop from the bottom instead, preserving faces and heads in the visible area.

## Changes

**File modified:**
- `src/assets/tailwind/components/imageblock.css:33` - Added `object-top` utility class

**Before:**
```css
.image-block .full > img {
  @apply w-full object-cover h-full;
}
```

**After:**
```css
.image-block .full > img {
  @apply w-full object-cover h-full object-top;
}
```

## Testing

- ✅ Built and deployed to sandbox
- ✅ All tests passing
- 🔍 **Manual testing needed:** Check banner images on liberalistene.org to verify heads are no longer cropped

## Visual Impact

This affects all ImageBlock/hero banner images across the site. The change should be subtle - images will now show more of the top portion and less of the bottom when cropping is needed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>