### PR TITLE
chore: update workflows to use master branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - develop
+      - master
       - feature/**
   pull_request:
     branches:
-      - develop
       - master
 
 jobs:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,7 +3,6 @@ name: Deploy Storybook
 on:
   push:
     branches:
-      - develop
       - master
 
 jobs:


### PR DESCRIPTION
## Summary

Updates CI workflows to remove develop branch references now that master is the default and only active branch.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- **Push triggers:** `develop` → `master` (kept `feature/**`)
- **PR targets:** Removed `develop`, kept `master` only

### Storybook Workflow (`.github/workflows/storybook.yml`)
- **Push triggers:** Removed `develop`, kept `master` only

## Branch Protection Updated

Also updated master branch protection to allow semantic-release to work:
- ✅ Removed PR requirement (allows semantic-release to push directly)
- ✅ Kept status check requirement (Test must pass)
- ✅ Kept force push and deletion blocks
- ✅ Set `enforce_admins: false` (GitHub Actions can bypass)

This fixes the semantic-release failure from the previous release workflow run.

## Impact

After merging:
- CI runs on pushes to `master` or `feature/**` branches
- Pull requests only target `master`
- Storybook deploys only from `master`
- Semantic-release can create release commits automatically

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>