### PR TITLE
fix: use fine-grained PAT for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
 
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
       ENONIC_CLI_REMOTE_URL: ${{ secrets.ENONIC_CLI_REMOTE_URL }}
       ENONIC_CLI_REMOTE_USER: ${{ secrets.ENONIC_CLI_REMOTE_USER }}
       ENONIC_CLI_REMOTE_PASS: ${{ secrets.ENONIC_CLI_REMOTE_PASS }}
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Fixes the semantic-release workflow by using a fine-grained Personal Access Token (PAT) instead of the default `GITHUB_TOKEN`. This allows semantic-release to push release commits to the protected master branch.

## Problem

The release workflow has been failing with:
```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Required status check "Test (22.15.1)" is expected.
```

The default `GITHUB_TOKEN` provided by GitHub Actions does not have sufficient permissions to bypass branch protection rules, even with `enforce_admins: false`.

## Solution

Created a fine-grained PAT with the following permissions:
- **Repository:** `Liberalistene-Developers/lib.no`
- **Contents:** Read and write (allows pushing commits)
- **Pull requests:** Read and write (for creating releases)

Stored as `SEMANTIC_RELEASE_TOKEN` in GitHub Secrets.

## Changes

**File modified:** `.github/workflows/release.yml`

1. **Line 31:** Changed `GITHUB_TOKEN` env var to use `SEMANTIC_RELEASE_TOKEN`
   ```yaml
   GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
   ```

2. **Line 41:** Added `token` parameter to checkout action
   ```yaml
   - name: Checkout
     uses: actions/checkout@v5
     with:
       fetch-depth: 0
       token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
   ```

## Testing

Once merged, the next push to master will trigger the release workflow. The PAT should allow semantic-release to:
- ✅ Push release commits to master
- ✅ Create git tags
- ✅ Create GitHub releases
- ✅ Upload release artifacts

## Impact

After merging, automated releases will work again. Semantic-release will be able to:
- Analyze commits and determine version bumps
- Generate changelogs
- Create release commits
- Publish to GitHub

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>