### PR TITLE
fix: update lib-asset to 1.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     //include "com.enonic.xp:lib-websocket:${xpVersion}"
 
     // The version numbers must be here (or dependabot will fail)
-    include 'com.enonic.lib:lib-asset:1.0.2'
+    include 'com.enonic.lib:lib-asset:1.0.3'
     // Removed lib-guillotine:6.2.1 - migrated to Guillotine app v7
     include 'com.enonic.lib:lib-react4xp:6.0.1'
     include 'com.enonic.lib:lib-menu:4.2.1'


### PR DESCRIPTION
## Summary

Update lib-asset dependency from 1.0.2 to 1.0.3 to test the deployment workflow with the new RELEASE_BUILT flag mechanism.

## Changes

- Update `lib-asset` from 1.0.2 to 1.0.3

## Test Plan

This PR will test the new deployment workflow:
- [ ] Semantic-release should create a patch release (v2.0.2)
- [ ] RELEASE_BUILT flag should be set during prepareCmd
- [ ] Deploy to Enonic step should run
- [ ] We can observe if deployment succeeds or times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)