### PR TITLE
fix: clean up .env.example to remove unused variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,53 +2,12 @@
 # Copy this file to .env and fill in your actual values
 # IMPORTANT: Never commit .env files to version control
 
-# Enonic XP Configuration
-# XP_HOME=/path/to/xp/home
-
-# Deployment Configuration
-# ENONIC_SANDBOX=your-sandbox-name
-
-# Application Configuration
-# APP_NAME=lib.no
-# APP_VERSION=1.10.2
-
-# Database Configuration (if using external database)
-# DB_HOST=localhost
-# DB_PORT=5432
-# DB_NAME=enonic
-# DB_USER=enonic
-# DB_PASSWORD=
-
-# API Keys and Secrets
-# Add any API keys, tokens, or secrets your application uses here
-# EXAMPLE_API_KEY=
-# EXAMPLE_API_SECRET=
-
-# Guillotine/GraphQL Configuration
-# GUILLOTINE_API_KEY=
-
-# Email Configuration (if using SMTP)
-# SMTP_HOST=
-# SMTP_PORT=
-# SMTP_USER=
-# SMTP_PASSWORD=
-
-# External Service URLs
-# EXTERNAL_SERVICE_URL=
-
-# Feature Flags
-# FEATURE_NEW_LAYOUT=false
-
-# Logging Level
-# LOG_LEVEL=info
-
-# Security
-# SESSION_SECRET=
-# JWT_SECRET=
-
-# Content Security Policy (CSP) Configuration
-# Uncomment and modify if you need to customize CSP headers
-# CSP_SCRIPT_SRC='self' 'unsafe-inline'
-# CSP_STYLE_SRC='self' 'unsafe-inline'
-# CSP_IMG_SRC='self' data: https:
-# CSP_FONT_SRC='self' data:
+# Note: This project currently does not use environment variables in the application code.
+#
+# Deployment credentials are configured as GitHub Secrets for CI/CD:
+# - ENONIC_CLI_REMOTE_URL
+# - ENONIC_CLI_REMOTE_USER
+# - ENONIC_CLI_REMOTE_PASS
+#
+# For local development, you can configure Enonic CLI remotes directly:
+# enonic remote add <name> <url> -u <user> -p <password>


### PR DESCRIPTION
## Summary

Remove all unused environment variable placeholders from .env.example. The project does not currently use environment variables in application code.

## Changes

- Remove 50+ lines of unused environment variable placeholders
- Document that the project doesn't use environment variables in code
- Clarify that deployment credentials are configured as GitHub Secrets
- Add instructions for configuring Enonic CLI for local development

## Before (55 lines)
```
# Database Configuration (if using external database)
# SMTP Configuration
# Feature Flags
# CSP Configuration
... (and many more unused variables)
```

## After (14 lines)
Clear documentation explaining:
- Project doesn't use env vars in code
- Deployment credentials are in GitHub Secrets
- How to configure Enonic CLI locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)