### PR TITLE
chore: add write permissions to Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,6 +8,11 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fix the Claude PR review workflow by adding explicit write permissions. The workflow was failing with "Actor does not have write permissions to the repository" error because it lacked the necessary permissions to post comments.

## Changes

- Add `permissions` block to `.github/workflows/claude-pr-review.yml`
- Grant `contents: read` - Access repository contents
- Grant `pull-requests: write` - Post review comments on PRs
- Grant `issues: write` - Post comments on issues

## Why This Change?

Without explicit permissions, GitHub Actions defaults to read-only access. The Claude review action needs write permissions to post its review comments on pull requests and respond to issue comments.

## Closes

- Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)