### PR TITLE
chore: add write permissions to Claude Dependabot review workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   claude-dependabot-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fix the Claude Dependabot review workflow by adding explicit write permissions. This workflow will fail with "Actor does not have write permissions to the repository" error when trying to post review comments on Dependabot PRs without these permissions.

## Changes

- Add `permissions` block to `.github/workflows/claude-dependabot.yml`
- Grant `contents: read` - Access repository contents
- Grant `pull-requests: write` - Post review comments on PRs
- Grant `issues: write` - Post comments on issues

## Why This Change?

Without explicit permissions, GitHub Actions defaults to read-only access. The Claude review action needs write permissions to post its automated review comments on Dependabot dependency update PRs.

## Related

- Same issue as #92 (Claude PR review workflow)
- This completes the audit of all 5 GitHub workflows - only these 2 Claude review workflows needed the fix

## Closes

- Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)