### PR TITLE
ci: add JAR artifact upload and disable broken deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,11 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: liberalistene-jar-ci-${{ github.sha }}
+          path: build/libs/Liberalistene.jar
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,22 @@ jobs:
       - name: Release
         run: npx semantic-release
 
-      - name: Deploy to Enonic
+      - name: Upload JAR artifact
         if: env.RELEASE_BUILT == 'true'
-        uses: docker://enonic/enonic-ci:7.15
-        env:
-          ENONIC_CLI_REMOTE_URL: ${{ secrets.ENONIC_CLI_REMOTE_URL }}
-          ENONIC_CLI_REMOTE_USER: ${{ secrets.ENONIC_CLI_REMOTE_USER }}
-          ENONIC_CLI_REMOTE_PASS: ${{ secrets.ENONIC_CLI_REMOTE_PASS }}
+        uses: actions/upload-artifact@v6
         with:
-          args: enonic app install --file build/libs/Liberalistene.jar
+          name: liberalistene-jar-${{ github.sha }}
+          path: build/libs/Liberalistene.jar
+          retention-days: 90
+          if-no-files-found: error
+
+      # Disabled: Enonic deployment currently not working
+      # - name: Deploy to Enonic
+      #   if: env.RELEASE_BUILT == 'true'
+      #   uses: docker://enonic/enonic-ci:7.15
+      #   env:
+      #     ENONIC_CLI_REMOTE_URL: ${{ secrets.ENONIC_CLI_REMOTE_URL }}
+      #     ENONIC_CLI_REMOTE_USER: ${{ secrets.ENONIC_CLI_REMOTE_USER }}
+      #     ENONIC_CLI_REMOTE_PASS: ${{ secrets.ENONIC_CLI_REMOTE_PASS }}
+      #   with:
+      #     args: enonic app install --file build/libs/Liberalistene.jar


### PR DESCRIPTION
Closes #113

Add artifact upload to both CI and release workflows to enable manual JAR retrieval and deployment.

## Changes

**`.github/workflows/release.yml`:**
- Add JAR artifact upload step (90-day retention)
- Disable broken Enonic auto-deployment (commented out with explanation)
- Unique naming: `liberalistene-jar-{commit-sha}`

**`.github/workflows/ci.yml`:**
- Add JAR artifact upload step after build (30-day retention)
- Unique naming: `liberalistene-jar-ci-{commit-sha}`
- Fail if JAR file not found (`if-no-files-found: error`)

## Benefits

- **Manual deployment** - Download JAR from artifacts and deploy manually
- **Build verification** - Verify JAR was built correctly
- **Rollback support** - Retrieve previous build artifacts if needed
- **CI testing** - Download and test JARs from CI builds

## How to Download Artifacts

1. Go to the workflow run page
2. Scroll to "Artifacts" section at the bottom
3. Click the artifact name to download
4. Manually deploy using `enonic app install --file Liberalistene.jar`

## Artifact Retention

- **Release builds:** 90 days
- **CI builds:** 30 days

This ensures we can retrieve built JARs for manual deployment until the Enonic auto-deployment is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)