### PR TITLE
fix: add comprehensive CSS styling for rich-text content

### DIFF
--- a/src/assets/tailwind/typography.css
+++ b/src/assets/tailwind/typography.css
@@ -59,6 +59,158 @@
     line-height: var(--text-rich-line-height);
   }
 
+  /* Rich text nested element styles */
+  .rich-text h1 {
+    @apply text-primary-700 font-sans mb-6 mt-8;
+
+    font-size: var(--text-h1);
+    line-height: var(--text-h1-line-height);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .rich-text h1:first-child {
+    @apply mt-0;
+  }
+
+  .rich-text h2 {
+    @apply text-primary-500 font-sans mb-5 mt-7;
+
+    font-size: var(--text-h2);
+    line-height: var(--text-h2-line-height);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .rich-text h2:first-child {
+    @apply mt-0;
+  }
+
+  .rich-text h3 {
+    @apply text-primary-500 font-sans mb-4 mt-6;
+
+    font-size: var(--text-h3);
+    line-height: var(--text-h3-line-height);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .rich-text h3:first-child {
+    @apply mt-0;
+  }
+
+  .rich-text p {
+    @apply mb-4;
+  }
+
+  .rich-text p:last-child {
+    @apply mb-0;
+  }
+
+  .rich-text a {
+    @apply text-primary-700 underline font-bold;
+  }
+
+  .rich-text a:hover {
+    @apply text-primary-500;
+  }
+
+  .rich-text strong {
+    @apply font-bold;
+  }
+
+  .rich-text em {
+    @apply italic;
+  }
+
+  .rich-text ul,
+  .rich-text ol {
+    @apply mb-4 pl-8;
+  }
+
+  .rich-text ul {
+    @apply list-disc;
+  }
+
+  .rich-text ol {
+    @apply list-decimal;
+  }
+
+  .rich-text li {
+    @apply mb-2;
+  }
+
+  .rich-text li:last-child {
+    @apply mb-0;
+  }
+
+  .rich-text blockquote {
+    @apply border-l-4 border-primary-500 pl-4 py-2 mb-4 italic text-primary-500;
+  }
+
+  .rich-text img {
+    @apply max-w-full h-auto my-4;
+  }
+
+  .rich-text figure {
+    @apply my-6 mx-0;
+  }
+
+  .rich-text figure img {
+    @apply max-w-full h-auto;
+  }
+
+  .rich-text figcaption {
+    @apply text-sm text-primary-500 mt-2 text-center;
+  }
+
+  .rich-text hr {
+    @apply border-t-2 border-primary-300 my-6;
+  }
+
+  .rich-text table {
+    @apply w-full mb-4 border-collapse;
+  }
+
+  .rich-text th,
+  .rich-text td {
+    @apply border border-primary-300 px-4 py-2 text-left;
+  }
+
+  .rich-text th {
+    @apply bg-primary-700 text-white font-bold;
+  }
+
+  .rich-text code {
+    @apply bg-gray-100 px-2 py-1 rounded text-sm font-mono;
+  }
+
+  .rich-text pre {
+    @apply bg-gray-100 p-4 rounded mb-4 overflow-x-auto;
+  }
+
+  .rich-text pre code {
+    @apply bg-transparent p-0;
+  }
+
+  /* Mobile responsive styles for rich-text */
+  @media (width <= 414px) {
+    .rich-text h1 {
+      font-size: var(--text-h1-mobile);
+      line-height: var(--text-h1-mobile-line-height);
+      font-weight: var(--font-weight-heading-mobile);
+    }
+
+    .rich-text h2 {
+      font-size: var(--text-h2-mobile);
+      line-height: var(--text-h2-mobile-line-height);
+      font-weight: var(--font-weight-heading-mobile);
+    }
+
+    .rich-text h3 {
+      font-size: var(--text-h3-mobile);
+      line-height: var(--text-h3-mobile-line-height);
+      font-weight: var(--font-weight-heading-mobile);
+    }
+  }
+
   /* Typography utilities */
   .text-link {
     @apply font-bold;


### PR DESCRIPTION
Closes #111

Add comprehensive nested element styles to `.rich-text` class to properly render user-generated HTML content from CMS.

## Problem

User-generated HTML content appeared unstyled because the `.rich-text` class only defined basic text properties (color, font, size, line-height) but had **no styling for nested HTML elements** that users write in the CMS.

**Live example:** https://www.liberalistene.org/kunnskap/hva-er-liberalisme/

## Solution

Add comprehensive nested element styles for all HTML elements users might write.

**Styles added for:**
- **Headings (h1, h2, h3)** - Proper margins and hierarchy
- **Paragraphs** - Spacing between paragraphs
- **Links** - Color, underline, and hover states
- **Lists (ul, ol, li)** - Bullets/numbers and indentation
- **Emphasis** - Strong (bold) and em (italic)
- **Blockquotes** - Left border and styling
- **Images & figures** - Responsive sizing
- **Tables** - Borders and themed headers
- **Code blocks** - Inline and block formatting
- **Horizontal rules** - Themed borders
- **Mobile responsive** - Adjusted heading sizes for mobile

## Changes

**File:** `src/assets/tailwind/typography.css` (+152 lines)

All changes are **purely additive** - existing `.rich-text`, `.text-link`, and `.title` styles are completely preserved with no modifications.

## Impact

- ✅ Fixes missing visual hierarchy in article content
- ✅ Improves readability with proper spacing
- ✅ Enhances accessibility with clear element differentiation
- ✅ Maintains brand consistency using existing theme variables
- ✅ **No breaking changes** - existing components unaffected

## Testing

After merge, the CI workflow will upload a JAR artifact (thanks to #113!). Download it from the workflow run and manually deploy to test on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)