### PR TITLE
fix: handle 'normal' sort option in runQuery function (closes #118)

### DIFF
--- a/src/main/resources/react4xp/utils/query.ts
+++ b/src/main/resources/react4xp/utils/query.ts
@@ -50,7 +50,9 @@ export const runQuery = (
   sortMethod?: string,
   start: number = 0
 ): string[] | undefined => {
-  const sort = sortMethod ? `_modifiedTime ${sortMethod}` : undefined;
+  const sort = sortMethod && sortMethod !== 'normal'
+    ? `_modifiedTime ${sortMethod}`
+    : undefined;
 
   const search: SearchParams = {
     key,


### PR DESCRIPTION
## Summary
Fixes the FAQ List part crash when using query mode with the "normal" (default) sorting option.

## Problem
The FAQ page at https://www.liberalistene.org/politikk/faq was broken with this error:
```
Error in processor for part "lib.no:faqlist" at: /main/1/content/0
line 1, column 15:
(, ASC, DESC or EOF expected, normal encountered.
```

## Root Cause
The `runQuery` function in `utils/query.ts` was creating invalid sort expressions like `"_modifiedTime normal"` when the sort method was `"normal"` (the default from the query mixin). Enonic XP only accepts `ASC` or `DESC` as sort directions.

## Solution
Updated `runQuery` to treat `"normal"` as undefined (no sorting), matching the behavior already implemented in the `findItems` function.

## Changes
- `src/main/resources/react4xp/utils/query.ts` - Fixed sort expression logic

## Test Plan
- [x] Code change made
- [ ] Deploy to test environment
- [ ] Verify FAQ page loads correctly at /politikk/faq
- [ ] Test with different sorting options (normal, asc, desc)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)