### PR TITLE
fix: add content type filter to FaqList query and fix filter logic (closes #120)

### DIFF
--- a/src/main/resources/react4xp/parts/faqlist/FaqListProcessor.ts
+++ b/src/main/resources/react4xp/parts/faqlist/FaqListProcessor.ts
@@ -99,7 +99,7 @@ export const faqListProcessor: ComponentProcessor<'lib.no:faqlist'> = ({componen
       const queryItems = runQuery(
         queryConfig.queryroot,
         queryConfig.count || 10,
-        undefined,
+        'lib.no:faq',
         queryConfig.querysorting
       );
       if (queryItems) {

--- a/src/main/resources/react4xp/utils/query.ts
+++ b/src/main/resources/react4xp/utils/query.ts
@@ -26,7 +26,7 @@ export const findChildren = (
   }
 
   return children.hits.filter(({type}) =>
-    type ? type === contentType : true
+    type && contentType ? type === contentType : true
   );
 };
 


### PR DESCRIPTION
## Summary
Fixes the FAQ List part to properly display FAQs when using query mode by adding the missing content type filter and correcting the filter logic.

## Problem
The FAQ page at https://www.liberalistene.org/politikk/faq was empty despite having published FAQ content in the CMS.

## Root Causes

### Bug 1: Missing Content Type in FaqListProcessor
The processor was passing `undefined` instead of `'lib.no:faq'` as the content type parameter. This was a **regression introduced during the React4xp v3→v6 migration**. The v1.0 code correctly passed `'lib.no:faq'`.

### Bug 2: Incorrect Filter Logic in query.ts  
The `findChildren` function had backwards filter logic. When `contentType` was `undefined`, it filtered OUT items with a type instead of returning all items.

**Before:**
```typescript
return children.hits.filter(({type}) =>
  type ? type === contentType : true  // ❌ Wrong!
);
```

When `contentType = undefined` and item has `type = 'lib.no:faq'`:
- Evaluates: `'lib.no:faq' ? 'lib.no:faq' === undefined : true`
- Result: `false` → FAQ filtered OUT ❌

**After:**
```typescript
return children.hits.filter(({type}) =>
  type && contentType ? type === contentType : true  // ✅ Correct!
);
```

## Solution

1. **FaqListProcessor.ts** - Changed `undefined` to `'lib.no:faq'` on line 102
2. **query.ts** - Fixed filter logic to check both `type` and `contentType` exist before filtering

## Changes
- `src/main/resources/react4xp/parts/faqlist/FaqListProcessor.ts` - Add content type filter
- `src/main/resources/react4xp/utils/query.ts` - Fix filter logic

## Test Plan
- [x] Code changes made
- [ ] Deploy to test environment
- [ ] Verify FAQ page loads correctly at /politikk/faq
- [ ] Verify FAQs display in query mode
- [ ] Verify manual selection mode still works

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)