### PR TITLE
fix: add missing content type filters to list processors (closes #122)

### DIFF
--- a/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationProcessor.ts
+++ b/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationProcessor.ts
@@ -126,7 +126,7 @@ export const boardPresentationProcessor: ComponentProcessor<'lib.no:boardpresent
       const queryItems = runQuery(
         queryConfig.queryroot,
         queryConfig.count || 10,
-        undefined,
+        'lib.no:group',
         queryConfig.querysorting
       );
       if (queryItems) {

--- a/src/main/resources/react4xp/parts/booklist/BookListProcessor.ts
+++ b/src/main/resources/react4xp/parts/booklist/BookListProcessor.ts
@@ -133,7 +133,7 @@ export const bookListProcessor: ComponentProcessor<'lib.no:booklist'> = ({compon
       const queryItems = runQuery(
         queryConfig.queryroot,
         queryConfig.count || 10,
-        undefined,
+        'lib.no:book',
         queryConfig.querysorting
       );
       if (queryItems) {

--- a/src/main/resources/react4xp/parts/budgetcutlist/BudgetCutListProcessor.ts
+++ b/src/main/resources/react4xp/parts/budgetcutlist/BudgetCutListProcessor.ts
@@ -147,7 +147,7 @@ export const budgetCutListProcessor: ComponentProcessor<'lib.no:budgetcutlist'> 
       const queryItems = runQuery(
         queryConfig.queryroot,
         queryConfig.count || 10,
-        undefined,
+        'lib.no:budgetcut',
         queryConfig.querysorting
       );
       if (queryItems) {

--- a/src/main/resources/react4xp/parts/candidatepresentation/CandidatePresentationProcessor.ts
+++ b/src/main/resources/react4xp/parts/candidatepresentation/CandidatePresentationProcessor.ts
@@ -111,7 +111,7 @@ export const candidatePresentationProcessor: ComponentProcessor<'lib.no:candidat
       const queryItems = runQuery(
         queryConfig.queryroot,
         queryConfig.count || 10,
-        undefined,
+        'lib.no:candidate',
         queryConfig.querysorting
       );
       if (queryItems) {


### PR DESCRIPTION
## Summary
Fixes 4 list processors that were missing content type filters due to a regression during the React4xp v3→v6 migration.

## Problem
Multiple list processors were passing `undefined` instead of specific content types to `runQuery()`, causing inefficient queries that fetch all content types and filter in JavaScript.

## Root Cause
Same regression as #120 (FaqList) - during the React4xp v3→v6 migration, explicit content type parameters were accidentally changed to `undefined`.

## Solution
Restored v1.0 behavior by adding explicit content type filters to 4 processors:

| Processor | v1.0 | v2.0 (before) | v2.0 (after) |
|-----------|------|---------------|--------------|
| BookListProcessor | `'lib.no:book'` | `undefined` | ✅ `'lib.no:book'` |
| BudgetCutListProcessor | `'lib.no:budgetcut'` | `undefined` | ✅ `'lib.no:budgetcut'` |
| CandidatePresentationProcessor | `'lib.no:candidate'` | `undefined` | ✅ `'lib.no:candidate'` |
| BoardPresentationProcessor | `'lib.no:group'` | `undefined` | ✅ `'lib.no:group'` |
| SubmenuProcessor | `''` (empty) | `undefined` | ⚪ `undefined` (intentional) |

**Note:** SubmenuProcessor intentionally keeps `undefined` because it's a navigation component that should accept any content type.

## Benefits
- **Performance:** Filters at database level instead of JavaScript
- **Correctness:** Matches v1.0 behavior
- **Efficiency:** Reduces data transfer and processing

## Changes
- `src/main/resources/react4xp/parts/boardpresentation/BoardPresentationProcessor.ts`
- `src/main/resources/react4xp/parts/booklist/BookListProcessor.ts`
- `src/main/resources/react4xp/parts/budgetcutlist/BudgetCutListProcessor.ts`
- `src/main/resources/react4xp/parts/candidatepresentation/CandidatePresentationProcessor.ts`

## Related Issues
- #120 - FaqList content type fix (same root cause)
- #118 - "normal" sorting fix

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)