### PR TITLE
fix: restore list styling and add fallback titles in TableOfContents (closes #125)

### DIFF
--- a/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
+++ b/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
@@ -36,12 +36,18 @@ const Section: FC<SectionProps> = ({
       <ContentLink title={title} parentTitle={parentTitle} />
       {displayParts && displayParts.length > 0
         ? (
-          <ul className="content-section-parts">
-            {displayParts.map(({ key, title: partTitle }) => (
-              <li key={key} className="content-section-part">
-                <ContentLink title={partTitle} parentTitle={title} />
-              </li>
-            ))}
+          <ul className="content-section-parts list-circle pl-6 mt-2">
+            {displayParts.map(({ key, title: partTitle }, index) => {
+              const displayTitle = partTitle && partTitle.trim() !== ''
+                ? partTitle
+                : `${title} #${index + 1}`;
+
+              return (
+                <li key={key} className="content-section-part">
+                  <ContentLink title={displayTitle} parentTitle={title} />
+                </li>
+              );
+            })}
           </ul>
         )
         : null}
@@ -100,7 +106,7 @@ export const TableOfContent: FC<TableOfContentProps> = ({
   title = '',
   sections = []
 }) => (
-  <ul className="table-of-content">
+  <ul className="table-of-content list-disc pl-6">
     {sections && sections.map(({ key, ...props }) =>
       <Section key={key} {...props} parentTitle={title} />
     )}


### PR DESCRIPTION
## Summary
Fixes the TableOfContents component to display properly with bullets and indentation, and generates meaningful titles for items without proper titles in the CMS.

## Problem
The TableOfContents had two visual issues:

1. **Flat, unstyled list** - No bullets or indentation, breaking the visual hierarchy
2. **Empty entries** - Items without titles showed as just bullets with no clickable text

**Before:**
- Flat list with no bullets
- "1.", "2.", "3." entries with no text for resolutions missing titles

**After:**
- Proper nested bullet list with disc/circle bullets
- Meaningful fallback titles like "Resolusjoner 2021 #1"

## Root Causes

### Issue 1: Missing List Styling
During the Tailwind CSS migration, Tailwind's reset removed all default browser list styling. The v1.0 version had no custom CSS - it relied on browser defaults for `<ul>` and `<li>` bullets and indentation.

### Issue 2: Empty Titles
Some resolutions in the CMS don't have proper titles (stored as bulleted lists in the description instead). The component rendered these as empty list items.

## Solution

### Fix 1: Add Tailwind List Classes

**Main list:**
```tsx
<ul className="table-of-content list-disc pl-6">
```

**Nested parts list:**
```tsx
<ul className="content-section-parts list-circle pl-6 mt-2">
```

**Tailwind classes:**
- `list-disc` - Disc bullets for main sections
- `list-circle` - Circle bullets for nested items
- `pl-6` - Padding-left for indentation
- `mt-2` - Top margin for spacing

### Fix 2: Generate Fallback Titles

For items without titles, generate meaningful fallback using parent section title + index:

```tsx
const displayTitle = partTitle && partTitle.trim() !== ''
  ? partTitle
  : `${title} #${index + 1}`;
```

**Example output:**
- "Resolusjoner 2021 #1" (no title in CMS)
- "Resolusjoner 2021 #2" (no title in CMS)
- "Driveplikt og boplikt på gård" (has title in CMS)

## Changes
- `src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx` - Added Tailwind classes and fallback title logic

## Impact
- **Restores proper visual hierarchy** with bullets and indentation
- **Makes all items navigable** with meaningful link text
- **No breaking changes** - only visual improvements

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)