### PR TITLE
fix: improve spacing in programme TOC (closes #127)

### DIFF
--- a/src/main/resources/react4xp/common/ProgrammeMain/ProgrammeMain.tsx
+++ b/src/main/resources/react4xp/common/ProgrammeMain/ProgrammeMain.tsx
@@ -68,7 +68,7 @@ export const ProgrammeMain: FC<ProgrammeMainProps> = ({
 
         {tableOfContent
           ? (
-            <div>
+            <div className="mt-8 mb-10">
               <TableOfContent title={title} sections={sections} />
             </div>
           )

--- a/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
+++ b/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
@@ -32,7 +32,7 @@ const Section: FC<SectionProps> = ({
   const displayParts = parts.filter(({ type }) => type === 'lib.no:programme-part');
 
   return (
-    <li className="content-section">
+    <li className="content-section mb-4">
       <ContentLink title={title} parentTitle={parentTitle} />
       {displayParts && displayParts.length > 0
         ? (


### PR DESCRIPTION
## Summary
- Added 2rem spacing between title and table of contents
- Added 2.5rem spacing between table of contents and sections  
- Added 1rem spacing between year sections within TOC

## Changes
- Modified `ProgrammeMain.tsx` to add `mt-8 mb-10` classes to TOC wrapper
- Modified `TableOfContent.tsx` to add `mb-4` class to section items

## Test Plan
- [ ] Build and deploy to test environment
- [ ] Verify spacing improvements on programme pages
- [ ] Check that all TOC sections have proper visual separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)