### PR TITLE
fix: handle number-only titles in TableOfContents (closes #128)

### DIFF
--- a/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
+++ b/src/main/resources/react4xp/common/TableOfContent/TableOfContent.tsx
@@ -38,9 +38,23 @@ const Section: FC<SectionProps> = ({
         ? (
           <ul className="content-section-parts list-circle pl-6 mt-2">
             {displayParts.map(({ key, title: partTitle }, index) => {
-              const displayTitle = partTitle && partTitle.trim() !== ''
-                ? partTitle
-                : `${title} #${index + 1}`;
+              const displayTitle = (() => {
+                const trimmedTitle = partTitle?.trim() || '';
+
+                // Check if title is empty
+                if (trimmedTitle === '') {
+                  return `${title} #${index + 1}`;
+                }
+
+                // Check if title is just a number with dot (and optional whitespace)
+                const match = partTitle?.match(/^(\d+)\.\s*$/);
+                if (match) {
+                  const number = match[1]; // Captured number from regex
+                  return `${number}. ${title} #${number}`;
+                }
+
+                return trimmedTitle;
+              })();
 
               return (
                 <li key={key} className="content-section-part">


### PR DESCRIPTION
## Summary
- Added regex validation to detect number-only titles (e.g., "1.", "2. ")
- Replaces them with meaningful fallbacks using section title
- Format: `{number}. {section title} #{number}`

## Example
- Title "1." under "Resolusjoner 2021" → "1. Resolusjoner 2021 #1"
- Title "2. " under "Resolusjoner 2021" → "2. Resolusjoner 2021 #2"

## Changes
- Modified `TableOfContent.tsx` to add regex pattern `/^(\d+)\.\s*$/`
- Captures number using regex group and reuses it in fallback title
- Handles optional trailing whitespace after the dot

## Test Plan
- [ ] Build and deploy to test environment
- [ ] Verify Resolusjoner 2021 items 1 and 2 display meaningful titles
- [ ] Check that normal titles still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)