### PR TITLE
fix: use BoardPresentationList component for board presentation part (closes #133)

### DIFF
--- a/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationPart.tsx
+++ b/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationPart.tsx
@@ -1,4 +1,4 @@
-import {BoardPresentation} from '/react4xp/common/BoardPresentation/BoardPresentation';
+import {BoardPresentationList} from '/react4xp/common/BoardPresentationList/BoardPresentationList';
 import {createPartShim} from '/react4xp/common/PartShim/PartShim';
 
-export const BoardPresentationPart = createPartShim(BoardPresentation);
+export const BoardPresentationPart = createPartShim(BoardPresentationList);


### PR DESCRIPTION
## Summary
- Fixed boardpresentation part to use correct component
- Changed from BoardPresentation → BoardPresentationList
- Now displays multiple boards correctly in query mode

## Problem
The part was using `BoardPresentation` which expects a `board` prop (single board), but the processor returns `items` (multiple boards). This prop mismatch caused nothing to display.

## Solution
Use `BoardPresentationList` component which expects `items` prop and correctly displays multiple boards.

## Changes
- Line 1: Import BoardPresentationList instead of BoardPresentation
- Line 4: Pass BoardPresentationList to createPartShim

## Root Cause
React4xp v3→v6 migration split the components but wired the Part to the wrong one.

## Test Plan
- [ ] Build and deploy to test environment
- [ ] Verify /fylkesstyrer page displays all regional boards
- [ ] Confirm query mode works correctly
- [ ] Test manual mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)