### PR TITLE
fix: handle single item from manual ItemSet selection (closes #135)

### DIFF
--- a/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationProcessor.ts
+++ b/src/main/resources/react4xp/parts/boardpresentation/BoardPresentationProcessor.ts
@@ -1,7 +1,7 @@
-import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
-import type {PartComponent} from '@enonic-types/core';
-import {runQuery} from '/react4xp/utils/query';
-import {mapGroup} from '/react4xp/utils/board';
+import type { PartComponent } from '@enonic-types/core';
+import type { ComponentProcessor } from '@enonic-types/lib-react4xp/DataFetcher';
+import { mapGroup } from '/react4xp/utils/board';
+import { runQuery } from '/react4xp/utils/query';
 
 /**
  * Board presentation part configuration from boardpresentation.xml schema.
@@ -38,8 +38,8 @@ interface BoardPresentationConfig {
     _selected?: string;
     /** Manual selection configuration */
     manual?: {
-      /** Array of manually selected group content IDs */
-      items?: string[];
+      /** Array of manually selected group content IDs (or single string if one item) */
+      items?: string | string[];
     };
     /** Query-based selection configuration */
     query?: {
@@ -119,7 +119,8 @@ export const boardPresentationProcessor: ComponentProcessor<'lib.no:boardpresent
   const items: string[] = [];
 
   if (selection === 'manual') {
-    items.push(...(config?.itemsSet?.manual?.items || []));
+    const manualItems = config?.itemsSet?.manual?.items ?? [];
+    items.push(...(Array.isArray(manualItems) ? manualItems : [manualItems]));
   } else if (selection === 'query') {
     const queryConfig = config?.itemsSet?.query;
     if (queryConfig?.queryroot) {


### PR DESCRIPTION
## Summary

Fixes #135 - BoardPresentationProcessor now correctly handles ItemSet returning a single string instead of an array when only one item is manually selected.

## Changes

- Updated `items` type definition from `string[]` to `string | string[]` to match actual runtime behavior
- Added `Array.isArray()` check to properly handle both single items and arrays
- Updated TypeScript interface documentation to reflect this behavior

## Root Cause

The ItemSet component returns a single `string` when one item is manually selected, but the processor expected an array. This caused runtime errors when trying to spread the value.

## Solution

Use `Array.isArray()` to detect whether the value is an array or single item, and wrap single items in an array before spreading.

## Testing

- [ ] Verify board presentation with single manual item selection
- [ ] Verify board presentation with multiple manual items
- [ ] Verify query mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)