### PR TITLE
fix: simple list layout takes full width in BoardPresentation (closes #141)

### DIFF
--- a/src/main/resources/react4xp/common/BoardPresentation/BoardPresentation.tsx
+++ b/src/main/resources/react4xp/common/BoardPresentation/BoardPresentation.tsx
@@ -87,7 +87,8 @@ export const BoardPresentation: FC<BoardPresentationProps> = ({
 
     {board && board.length > 0
       ? (
-        <div className={cx('w-full flex flex-row justify-center items-center [&>*]:w-1/2', {
+        <div className={cx('w-full flex flex-row justify-center items-center', {
+          '[&>*]:w-1/2': !noHighlighting, // Only apply 50% width when highlighting is enabled
           'flex-row-reverse gap-x-[10px] [&_.members]:flex-[0_0_content]': reverseOrder
         })}>
           {!noHighlighting && (


### PR DESCRIPTION
## Summary

Fixes #141 - Board presentation "Enkel liste" (simple list) display type now uses full width instead of being constrained to 50%, preventing member name truncation.

## Problem

When using the **"Enkel liste" (Simple list)** display type in the Board presentation component:

- The highlighted member section was correctly hidden (`noHighlighting={true}`)
- **BUT** the members list was still constrained to 50% width
- Long member names like "Jørgen Gundersen", "Simen Haugen", etc. were being cut off
- The content didn't extend beyond the header width

### Root Cause

**Before:**
```tsx
<div className={cx('w-full flex flex-row justify-center items-center [&>*]:w-1/2', {
  'flex-row-reverse gap-x-[10px] [&_.members]:flex-[0_0_content]': reverseOrder
})}>
```

The `[&>*]:w-1/2` class was **always applied**, making both children take 50% width regardless of whether highlighting was enabled.

## Solution

Made the width constraint conditional:

```tsx
<div className={cx('w-full flex flex-row justify-center items-center', {
  '[&>*]:w-1/2': !noHighlighting, // Only apply 50% width when highlighting is enabled
  'flex-row-reverse gap-x-[10px] [&_.members]:flex-[0_0_content]': reverseOrder
})}>
```

## Changes

**File:** `src/main/resources/react4xp/common/BoardPresentation/BoardPresentation.tsx`

- Moved `[&>*]:w-1/2` from base className to conditional object
- Only applies 50% width when `noHighlighting={false}` (highlighted mode)
- Added comment explaining the conditional logic

## Result

### Simple List Mode (`noHighlighting={true}`)
- ✅ Members list takes **100% width**
- ✅ Long names display fully without truncation
- ✅ Better readability and layout

### Highlighted Mode (`noHighlighting={false}`)
- ✅ Layout remains **50/50 split** (highlighted member + members list)
- ✅ No change to existing behavior
- ✅ Backward compatible

## Testing Checklist

- [ ] Simple list displays full-width member list
- [ ] Long member names no longer truncate
- [ ] Highlighted display still uses 50/50 split
- [ ] Reverse order option works correctly
- [ ] Mobile responsive layout works

## Impact

- **Minimal change:** Single line modification + comment
- **Surgical fix:** Only affects simple list display type
- **No breaking changes:** Highlighted mode behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)