### PR TITLE
fix: increase spacing in budget cut summary section (closes #161)

### DIFF
--- a/src/main/resources/react4xp/common/BudgetCut/BudgetCut.tsx
+++ b/src/main/resources/react4xp/common/BudgetCut/BudgetCut.tsx
@@ -174,7 +174,7 @@ export const BudgetCut: FC<BudgetCutProps> = ({
         <div className="text-right"><em><span>{labelNumberText}</span></em></div>
       )}
 
-      <div className="[&_dl_dt]:font-bold">
+      <div className="leading-relaxed [&_dl_dt]:mt-4 [&_dl_dt]:font-bold">
         {(cuts && cuts.length > 0 && (
           <dl>
             {cuts


### PR DESCRIPTION
## Summary
- Added `leading-relaxed` for better line-height in the budget cut summary section
- Added top margin on `<dt>` elements to visually separate each category in the definition list

## Test plan
- [x] Build passes
- [x] Deployed to sandbox and verified improved readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)