### PR TITLE
feat: add narrow article-width option to column layouts (closes #165)

### DIFF
--- a/src/assets/tailwind/layouts.css
+++ b/src/assets/tailwind/layouts.css
@@ -69,6 +69,10 @@
     @apply flex flex-col justify-center items-center mx-auto w-[911px] max-w-full;
   }
 
+  main .content-holder .content .content-item.article-width {
+    @apply w-[600px];
+  }
+
   main .content-holder .content .content-item .xp-page-editor-item-view.empty {
     @apply w-full;
   }

--- a/src/main/resources/react4xp/layouts/LayoutWrapper.tsx
+++ b/src/main/resources/react4xp/layouts/LayoutWrapper.tsx
@@ -1,0 +1,52 @@
+import {type ReactNode} from 'react';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+
+interface LayoutWrapperProps extends BaseLayoutProps {
+	contentItemClassName?: string;
+	children: ReactNode;
+}
+
+export const LayoutWrapper = ({
+	articleWidth = false,
+	background = '',
+	borderBottom = false,
+	fullWidth = false,
+	paddingBottom = false,
+	paddingTop = false,
+	contentItemClassName = '',
+	children,
+}: LayoutWrapperProps) => {
+	const contentHolderClasses = [
+		'content-holder',
+		background,
+		paddingBottom ? 'padding-bottom' : '',
+		paddingTop ? 'padding-top' : '',
+	].filter(Boolean).join(' ');
+
+	const contentClasses = [
+		'content',
+		fullWidth ? 'full' : '',
+	].filter(Boolean).join(' ');
+
+	const contentItemClasses = [
+		'content-item',
+		articleWidth ? 'article-width' : '',
+		contentItemClassName,
+	].filter(Boolean).join(' ');
+
+	const dividerClasses = [
+		'divider',
+		borderBottom ? 'visible' : '',
+	].filter(Boolean).join(' ');
+
+	return (
+		<div className={contentHolderClasses}>
+			<div className={contentClasses}>
+				<div className={contentItemClasses}>
+					{children}
+				</div>
+				<div className={dividerClasses}></div>
+			</div>
+		</div>
+	);
+};

--- a/src/main/resources/react4xp/layouts/fourcolumn/FourColumn.tsx
+++ b/src/main/resources/react4xp/layouts/fourcolumn/FourColumn.tsx
@@ -1,92 +1,48 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface FourColumnData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  middleLeftClassName?: string;
-  middleRightClassName?: string;
-  rightClassName?: string;
+interface FourColumnData extends BaseLayoutProps {
+	leftClassName?: string;
+	middleLeftClassName?: string;
+	middleRightClassName?: string;
+	rightClassName?: string;
 }
 
-export const FourColumn = ({component: {regions} = {} as LayoutData, meta, data = {}, common}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    middleLeftClassName = '',
-    middleRightClassName = '',
-    rightClassName = '',
-  } = data as FourColumnData;
+export const FourColumn = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
+	const {leftClassName = '', middleLeftClassName = '', middleRightClassName = '', rightClassName = '', ...baseProps} = data as FourColumnData;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const middleLeftClasses = ['content-child', 'middleleft', middleLeftClassName].filter(Boolean).join(' ');
-  const middleRightClasses = ['content-child', 'middleright', middleRightClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className="content-item items">
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              common={common}
-              name="left"
-            />
-          </div>
-          <div className={middleLeftClasses}>
-            <Region
-              data={regions?.middleleft?.components}
-              meta={meta}
-              common={common}
-              name="middleleft"
-            />
-          </div>
-          <div className={middleRightClasses}>
-            <Region
-              data={regions?.middleright?.components}
-              meta={meta}
-              common={common}
-              name="middleright"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              common={common}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName="items">
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'middleleft', middleLeftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middleleft?.components}
+					meta={meta}
+					name="middleleft"
+				/>
+			</div>
+			<div className={['content-child', 'middleright', middleRightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middleright?.components}
+					meta={meta}
+					name="middleright"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/fourcolumn/FourColumnProcessor.ts
+++ b/src/main/resources/react4xp/layouts/fourcolumn/FourColumnProcessor.ts
@@ -1,32 +1,19 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface FourColumnConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const fourColumnProcessor: ComponentProcessor<'lib.no:fourcolumn'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as FourColumnConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, middleLeftClassName, middleRightClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', '', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, middleLeftClassName, middleRightClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', '', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    middleLeftClassName,
-    middleRightClassName,
-    rightClassName,
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		middleLeftClassName,
+		middleRightClassName,
+		rightClassName,
+	};
 };

--- a/src/main/resources/react4xp/layouts/fourcolumn2row/FourColumn2Row.tsx
+++ b/src/main/resources/react4xp/layouts/fourcolumn2row/FourColumn2Row.tsx
@@ -1,98 +1,58 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface FourColumn2RowData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  middleLeftClassName?: string;
-  middleRightClassName?: string;
-  rightClassName?: string;
-  orderClass?: string;
+interface FourColumn2RowData extends BaseLayoutProps {
+	leftClassName?: string;
+	middleLeftClassName?: string;
+	middleRightClassName?: string;
+	rightClassName?: string;
+	orderClass?: string;
 }
 
-export const FourColumn2Row = ({component: {regions}, meta, data = {}}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    middleLeftClassName = '',
-    middleRightClassName = '',
-    rightClassName = '',
-    orderClass = '',
-  } = data as FourColumn2RowData;
+export const FourColumn2Row = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
+	const {leftClassName = '', middleLeftClassName = '', middleRightClassName = '', rightClassName = '', orderClass = '', ...baseProps} = data as FourColumn2RowData;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
+	const itemsClasses = ['items', orderClass].filter(Boolean).join(' ');
 
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const itemsClasses = ['content-item', 'items', orderClass].filter(Boolean).join(' ');
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const middleLeftClasses = ['content-child', 'middleleft', middleLeftClassName].filter(Boolean).join(' ');
-  const middleRightClasses = ['content-child', 'middleright', middleRightClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className={itemsClasses}>
-          <div className="content-child full">
-            <Region
-              data={regions?.top?.components}
-              meta={meta}
-              name="top"
-            />
-          </div>
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              name="left"
-            />
-          </div>
-          <div className={middleLeftClasses}>
-            <Region
-              data={regions?.middleleft?.components}
-              meta={meta}
-              name="middleleft"
-            />
-          </div>
-          <div className={middleRightClasses}>
-            <Region
-              data={regions?.middleright?.components}
-              meta={meta}
-              name="middleright"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName={itemsClasses}>
+			<div className="content-child full">
+				<Region
+					data={regions?.top?.components}
+					meta={meta}
+					name="top"
+				/>
+			</div>
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'middleleft', middleLeftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middleleft?.components}
+					meta={meta}
+					name="middleleft"
+				/>
+			</div>
+			<div className={['content-child', 'middleright', middleRightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middleright?.components}
+					meta={meta}
+					name="middleright"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/fourcolumn2row/FourColumn2RowProcessor.ts
+++ b/src/main/resources/react4xp/layouts/fourcolumn2row/FourColumn2RowProcessor.ts
@@ -1,34 +1,20 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface FourColumn2RowConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-  reverseroworder?: boolean;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const fourColumn2RowProcessor: ComponentProcessor<'lib.no:fourcolumn2row'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as FourColumn2RowConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string; reverseroworder?: boolean};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, middleLeftClassName, middleRightClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', '', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, middleLeftClassName, middleRightClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', '', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    middleLeftClassName,
-    middleRightClassName,
-    rightClassName,
-    orderClass: config?.reverseroworder ? 'reverse' : '',
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		middleLeftClassName,
+		middleRightClassName,
+		rightClassName,
+		orderClass: config?.reverseroworder ? 'reverse' : '',
+	};
 };

--- a/src/main/resources/react4xp/layouts/layoutUtils.ts
+++ b/src/main/resources/react4xp/layouts/layoutUtils.ts
@@ -1,0 +1,32 @@
+import type {LayoutComponent} from '@enonic-types/core';
+
+export interface BaseLayoutConfig {
+	articlewidth?: boolean;
+	background?: string;
+	borderbottom?: boolean;
+	fullwidth?: boolean;
+	paddingbottom?: boolean;
+	paddingtop?: boolean;
+}
+
+export interface BaseLayoutProps {
+	articleWidth?: boolean;
+	background?: string;
+	borderBottom?: boolean;
+	fullWidth?: boolean;
+	paddingBottom?: boolean;
+	paddingTop?: boolean;
+}
+
+export const extractBaseConfig = (component: unknown): BaseLayoutProps => {
+	const layoutComponent = component as LayoutComponent;
+	const config = layoutComponent.config as BaseLayoutConfig;
+	return {
+		articleWidth: config?.articlewidth,
+		background: config?.background,
+		borderBottom: config?.borderbottom,
+		fullWidth: config?.fullwidth,
+		paddingBottom: config?.paddingbottom,
+		paddingTop: config?.paddingtop,
+	};
+};

--- a/src/main/resources/react4xp/layouts/singlecolumn/SingleColumn.tsx
+++ b/src/main/resources/react4xp/layouts/singlecolumn/SingleColumn.tsx
@@ -1,58 +1,15 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface SingleColumnData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-}
-
-export const SingleColumn = ({
-  component,
-  common,
-  meta,
-  data,
-}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-  } = data as SingleColumnData;
-
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className="content-item">
-          <Region
-            data={component?.regions?.content?.components ?? []}
-            meta={meta}
-            common={common}
-            name="content"
-          />
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
-};
+export const SingleColumn = ({component, common, meta, data}: ComponentProps<LayoutData>) => (
+	<LayoutWrapper {...(data as BaseLayoutProps)}>
+		<Region
+			data={component?.regions?.content?.components ?? []}
+			meta={meta}
+			common={common}
+			name="content"
+		/>
+	</LayoutWrapper>
+);

--- a/src/main/resources/react4xp/layouts/singlecolumn/SingleColumnProcessor.ts
+++ b/src/main/resources/react4xp/layouts/singlecolumn/SingleColumnProcessor.ts
@@ -1,24 +1,7 @@
-import type { LayoutComponent, LayoutDescriptor } from '@enonic-types/core';
-import type { ComponentProcessor } from '@enonic-types/lib-react4xp/DataFetcher';
+import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
+import type {LayoutDescriptor} from '@enonic-types/core';
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
-interface SingleColumnConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-}
-
-export const singleColumnProcessor: ComponentProcessor<LayoutDescriptor> = ({component}) => {
-  const layoutComponent = component as LayoutComponent;
-  const config = layoutComponent.config as SingleColumnConfig;
-
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-  };
-};
+export const singleColumnProcessor: ComponentProcessor<LayoutDescriptor> = ({component}) => ({
+	...extractBaseConfig(component),
+});

--- a/src/main/resources/react4xp/layouts/singlecolumn2row/SingleColumn2Row.tsx
+++ b/src/main/resources/react4xp/layouts/singlecolumn2row/SingleColumn2Row.tsx
@@ -1,65 +1,31 @@
 import {Region, type ComponentProps, type LayoutData} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface SingleColumn2RowData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  orderClass?: string;
+interface SingleColumn2RowData extends BaseLayoutProps {
+	orderClass?: string;
 }
 
 export const SingleColumn2Row = ({meta, data = {}, component}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    orderClass = '',
-  } = data as SingleColumn2RowData;
-  const {regions} = component;
+	const {orderClass = '', ...baseProps} = data as SingleColumn2RowData;
+	const {regions} = component;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const itemsClasses = ['content-item', 'items', orderClass].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className={itemsClasses}>
-          <div className="content-child full">
-            <Region
-              data={regions?.top?.components}
-              meta={meta}
-              name="top"
-            />
-          </div>
-          <div className="content-child full">
-            <Region
-              data={regions?.bottom?.components}
-              meta={meta}
-              name="bottom"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName={['items', orderClass].filter(Boolean).join(' ')}>
+			<div className="content-child full">
+				<Region
+					data={regions?.top?.components}
+					meta={meta}
+					name="top"
+				/>
+			</div>
+			<div className="content-child full">
+				<Region
+					data={regions?.bottom?.components}
+					meta={meta}
+					name="bottom"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/singlecolumn2row/SingleColumn2RowProcessor.ts
+++ b/src/main/resources/react4xp/layouts/singlecolumn2row/SingleColumn2RowProcessor.ts
@@ -1,25 +1,13 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface SingleColumn2RowConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  reverseroworder?: boolean;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const singleColumn2RowProcessor: ComponentProcessor<'lib.no:singlecolumn2row'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as SingleColumn2RowConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {reverseroworder?: boolean};
 
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    orderClass: config?.reverseroworder ? 'reverse' : '',
-  };
+	return {
+		...extractBaseConfig(component),
+		orderClass: config?.reverseroworder ? 'reverse' : '',
+	};
 };

--- a/src/main/resources/react4xp/layouts/threecolumn/ThreeColumn.tsx
+++ b/src/main/resources/react4xp/layouts/threecolumn/ThreeColumn.tsx
@@ -1,78 +1,40 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface ThreeColumnData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  middleClassName?: string;
-  rightClassName?: string;
+interface ThreeColumnData extends BaseLayoutProps {
+	leftClassName?: string;
+	middleClassName?: string;
+	rightClassName?: string;
 }
 
 export const ThreeColumn = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    middleClassName = '',
-    rightClassName = '',
-  } = data as ThreeColumnData;
+	const {leftClassName = '', middleClassName = '', rightClassName = '', ...baseProps} = data as ThreeColumnData;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const middleClasses = ['content-child', 'middle', middleClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className="content-item items">
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              name="left"
-            />
-          </div>
-          <div className={middleClasses}>
-            <Region
-              data={regions?.middle?.components}
-              meta={meta}
-              name="middle"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName="items">
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'middle', middleClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middle?.components}
+					meta={meta}
+					name="middle"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/threecolumn/ThreeColumnProcessor.ts
+++ b/src/main/resources/react4xp/layouts/threecolumn/ThreeColumnProcessor.ts
@@ -1,31 +1,18 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface ThreeColumnConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const threeColumnProcessor: ComponentProcessor<'lib.no:threecolumn'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as ThreeColumnConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, middleClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, middleClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    middleClassName,
-    rightClassName,
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		middleClassName,
+		rightClassName,
+	};
 };

--- a/src/main/resources/react4xp/layouts/threecolumn2row/ThreeColumn2Row.tsx
+++ b/src/main/resources/react4xp/layouts/threecolumn2row/ThreeColumn2Row.tsx
@@ -1,92 +1,50 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface ThreeColumn2RowData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  middleClassName?: string;
-  rightClassName?: string;
-  orderClass?: string;
+interface ThreeColumn2RowData extends BaseLayoutProps {
+	leftClassName?: string;
+	middleClassName?: string;
+	rightClassName?: string;
+	orderClass?: string;
 }
 
 export const ThreeColumn2Row = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    middleClassName = '',
-    rightClassName = '',
-    orderClass = '',
-  } = data as ThreeColumn2RowData;
+	const {leftClassName = '', middleClassName = '', rightClassName = '', orderClass = '', ...baseProps} = data as ThreeColumn2RowData;
 
-  // console.info('ThreeColumn2Row data', JSON.stringify(data, null, 2));
+	const itemsClasses = ['items', orderClass].filter(Boolean).join(' ');
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const itemsClasses = ['content-item', 'items', orderClass].filter(Boolean).join(' ');
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const middleClasses = ['content-child', 'middle', middleClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  // console.info('ThreeColumn2Row classes', JSON.stringify(regions, null, 2));
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className={itemsClasses}>
-          <div className="content-child full">
-            <Region
-              data={regions?.top?.components}
-              meta={meta}
-              name="top"
-            />
-          </div>
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              name="left"
-            />
-          </div>
-          <div className={middleClasses}>
-            <Region
-              data={regions?.middle?.components}
-              meta={meta}
-              name="middle"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName={itemsClasses}>
+			<div className="content-child full">
+				<Region
+					data={regions?.top?.components}
+					meta={meta}
+					name="top"
+				/>
+			</div>
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'middle', middleClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.middle?.components}
+					meta={meta}
+					name="middle"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/threecolumn2row/ThreeColumn2RowProcessor.ts
+++ b/src/main/resources/react4xp/layouts/threecolumn2row/ThreeColumn2RowProcessor.ts
@@ -1,33 +1,19 @@
-import type { LayoutComponent } from '@enonic-types/core';
-import type { ComponentProcessor } from '@enonic-types/lib-react4xp/DataFetcher';
-
-interface ThreeColumn2RowConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-  reverseroworder?: boolean;
-}
+import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
+import type {LayoutComponent} from '@enonic-types/core';
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const threeColumn2RowProcessor: ComponentProcessor<'lib.no:threecolumn2row'> = ({component}) => {
-  const layoutComponent = component as LayoutComponent;
-  const config = layoutComponent.config as ThreeColumn2RowConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string; reverseroworder?: boolean};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, middleClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, middleClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', '', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    middleClassName,
-    rightClassName,
-    orderClass: config?.reverseroworder ? 'reverse' : '',
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		middleClassName,
+		rightClassName,
+		orderClass: config?.reverseroworder ? 'reverse' : '',
+	};
 };

--- a/src/main/resources/react4xp/layouts/twocolumn/TwoColumn.tsx
+++ b/src/main/resources/react4xp/layouts/twocolumn/TwoColumn.tsx
@@ -1,68 +1,32 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface TwoColumnData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  rightClassName?: string;
+interface TwoColumnData extends BaseLayoutProps {
+	leftClassName?: string;
+	rightClassName?: string;
 }
 
 export const TwoColumn = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    rightClassName = '',
-  } = data as TwoColumnData;
+	const {leftClassName = '', rightClassName = '', ...baseProps} = data as TwoColumnData;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className="content-item items">
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              name="left"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName="items">
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/twocolumn/TwoColumnProcessor.ts
+++ b/src/main/resources/react4xp/layouts/twocolumn/TwoColumnProcessor.ts
@@ -1,30 +1,17 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface TwoColumnConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const twoColumnProcessor: ComponentProcessor<'lib.no:twocolumn'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as TwoColumnConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    rightClassName,
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		rightClassName,
+	};
 };

--- a/src/main/resources/react4xp/layouts/twocolumn2row/TwoColumn2Row.tsx
+++ b/src/main/resources/react4xp/layouts/twocolumn2row/TwoColumn2Row.tsx
@@ -1,78 +1,40 @@
 import type {ComponentProps, LayoutData} from '@enonic/react-components';
 import {Region} from '@enonic/react-components';
+import {type BaseLayoutProps} from '/react4xp/layouts/layoutUtils';
+import {LayoutWrapper} from '/react4xp/layouts/LayoutWrapper';
 
-export interface TwoColumn2RowData extends Record<string, unknown> {
-  background?: string;
-  borderBottom?: boolean;
-  fullWidth?: boolean;
-  paddingBottom?: boolean;
-  paddingTop?: boolean;
-  leftClassName?: string;
-  rightClassName?: string;
-  orderClass?: string;
+interface TwoColumn2RowData extends BaseLayoutProps {
+	leftClassName?: string;
+	rightClassName?: string;
+	orderClass?: string;
 }
 
 export const TwoColumn2Row = ({component: {regions} = {} as LayoutData, meta, data = {}}: ComponentProps<LayoutData>) => {
-  const {
-    background = '',
-    borderBottom = false,
-    fullWidth = false,
-    paddingBottom = false,
-    paddingTop = false,
-    leftClassName = '',
-    rightClassName = '',
-    orderClass = '',
-  } = data as TwoColumn2RowData;
+	const {leftClassName = '', rightClassName = '', orderClass = '', ...baseProps} = data as TwoColumn2RowData;
 
-  const contentHolderClasses = [
-    'content-holder',
-    background,
-    paddingBottom ? 'padding-bottom' : '',
-    paddingTop ? 'padding-top' : ''
-  ].filter(Boolean).join(' ');
-
-  const contentClasses = [
-    'content',
-    fullWidth ? 'full' : ''
-  ].filter(Boolean).join(' ');
-
-  const dividerClasses = [
-    'divider',
-    borderBottom ? 'visible' : ''
-  ].filter(Boolean).join(' ');
-
-  const itemsClasses = ['content-item', 'items', orderClass].filter(Boolean).join(' ');
-  const leftClasses = ['content-child', 'left', leftClassName].filter(Boolean).join(' ');
-  const rightClasses = ['content-child', 'right', rightClassName].filter(Boolean).join(' ');
-
-  return (
-    <div className={contentHolderClasses}>
-      <div className={contentClasses}>
-        <div className={itemsClasses}>
-          <div className="content-child full">
-            <Region
-              data={regions?.top?.components}
-              meta={meta}
-              name="top"
-            />
-          </div>
-          <div className={leftClasses}>
-            <Region
-              data={regions?.left?.components}
-              meta={meta}
-              name="left"
-            />
-          </div>
-          <div className={rightClasses}>
-            <Region
-              data={regions?.right?.components}
-              meta={meta}
-              name="right"
-            />
-          </div>
-        </div>
-        <div className={dividerClasses}></div>
-      </div>
-    </div>
-  );
+	return (
+		<LayoutWrapper {...baseProps} contentItemClassName={['items', orderClass].filter(Boolean).join(' ')}>
+			<div className="content-child full">
+				<Region
+					data={regions?.top?.components}
+					meta={meta}
+					name="top"
+				/>
+			</div>
+			<div className={['content-child', 'left', leftClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.left?.components}
+					meta={meta}
+					name="left"
+				/>
+			</div>
+			<div className={['content-child', 'right', rightClassName].filter(Boolean).join(' ')}>
+				<Region
+					data={regions?.right?.components}
+					meta={meta}
+					name="right"
+				/>
+			</div>
+		</LayoutWrapper>
+	);
 };

--- a/src/main/resources/react4xp/layouts/twocolumn2row/TwoColumn2RowProcessor.ts
+++ b/src/main/resources/react4xp/layouts/twocolumn2row/TwoColumn2RowProcessor.ts
@@ -1,32 +1,18 @@
 import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {LayoutComponent} from '@enonic-types/core';
-
-interface TwoColumn2RowConfig {
-  background?: string;
-  borderbottom?: boolean;
-  fullwidth?: boolean;
-  paddingbottom?: boolean;
-  paddingtop?: boolean;
-  columnsLayout?: string;
-  reverseroworder?: boolean;
-}
+import {extractBaseConfig} from '/react4xp/layouts/layoutUtils';
 
 export const twoColumn2RowProcessor: ComponentProcessor<'lib.no:twocolumn2row'> = ({component}) => {
-  const layoutComponent = component as unknown as LayoutComponent;
-  const config = layoutComponent.config as TwoColumn2RowConfig;
+	const layoutComponent = component as unknown as LayoutComponent;
+	const config = layoutComponent.config as {columnsLayout?: string; reverseroworder?: boolean};
 
+	const columnsLayout = config?.columnsLayout || '';
+	const [leftClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', ''];
 
-  const columnsLayout = config?.columnsLayout || '';
-  const [leftClassName, rightClassName] = columnsLayout ? columnsLayout.split(',') : ['', ''];
-
-  return {
-    background: config?.background,
-    borderBottom: config?.borderbottom,
-    fullWidth: config?.fullwidth,
-    paddingBottom: config?.paddingbottom,
-    paddingTop: config?.paddingtop,
-    leftClassName,
-    rightClassName,
-    orderClass: config?.reverseroworder ? 'reverse' : '',
-  };
+	return {
+		...extractBaseConfig(component),
+		leftClassName,
+		rightClassName,
+		orderClass: config?.reverseroworder ? 'reverse' : '',
+	};
 };

--- a/src/main/resources/site/layouts/fourcolumn/fourcolumn.xml
+++ b/src/main/resources/site/layouts/fourcolumn/fourcolumn.xml
@@ -11,6 +11,7 @@
       </config>
       <default>one-25,one-25,one-25,one-25</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/fourcolumn2row/fourcolumn2row.xml
+++ b/src/main/resources/site/layouts/fourcolumn2row/fourcolumn2row.xml
@@ -11,6 +11,7 @@
       </config>
       <default>one-25,one-25,one-25,one-25</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/singlecolumn/singlecolumn.xml
+++ b/src/main/resources/site/layouts/singlecolumn/singlecolumn.xml
@@ -3,6 +3,7 @@
   <display-name i18n="layouts.singlecolumn.displayname">1 column</display-name>
   <description i18n="layouts.singlecolumn.description">A layout with one full width column</description>
   <form>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/singlecolumn2row/singlecolumn2row.xml
+++ b/src/main/resources/site/layouts/singlecolumn2row/singlecolumn2row.xml
@@ -2,6 +2,7 @@
 <layout xmlns="urn:enonic:xp:model:1.0">
   <display-name i18n="layouts.singlecolumn2row.displayname">1 column + 1</display-name>
   <form>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/threecolumn/threecolumn.xml
+++ b/src/main/resources/site/layouts/threecolumn/threecolumn.xml
@@ -17,6 +17,7 @@
       </config>
       <default>one-30,one-30,one-30</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/threecolumn2row/threecolumn2row.xml
+++ b/src/main/resources/site/layouts/threecolumn2row/threecolumn2row.xml
@@ -17,6 +17,7 @@
       </config>
       <default>one-30,one-30,one-30</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/twocolumn/twocolumn.xml
+++ b/src/main/resources/site/layouts/twocolumn/twocolumn.xml
@@ -18,6 +18,7 @@
       </config>
       <default>one,one</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/layouts/twocolumn2row/twocolumn2row.xml
+++ b/src/main/resources/site/layouts/twocolumn2row/twocolumn2row.xml
@@ -18,6 +18,7 @@
       </config>
       <default>one,one</default> 
     </input>
+    <mixin name="articlewidth" />
     <mixin name="fullwidth" />
     <mixin name="borderbottom" />
     <mixin name="background" />

--- a/src/main/resources/site/mixins/articlewidth/articlewidth.xml
+++ b/src/main/resources/site/mixins/articlewidth/articlewidth.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mixin xmlns="urn:enonic:xp:model:1.0">
+  <display-name>Article width</display-name>
+  <form>
+    <input name="articlewidth" type="CheckBox">
+      <label>Article width (600px)</label>
+      <config>
+        <alignment>right</alignment>
+      </config>
+    </input>
+  </form>
+</mixin>


### PR DESCRIPTION
## Summary
- Created shared `LayoutWrapper.tsx` and `layoutUtils.ts` to eliminate duplicated wrapper markup across all column layouts (-317 lines net)
- Added `articlewidth` mixin with a Content Studio checkbox that applies a 600px narrow content width
- Refactored all 8 column layouts (single/two/three/four column, each with 2-row variant) to use the shared utilities
- UnderConstruction layout intentionally excluded (different HTML structure)

## Test plan
- [x] All type checks pass
- [x] ESLint + Stylelint pass
- [x] 754 tests pass
- [x] Deployed and tested in sandbox
- [ ] Verify article-width checkbox appears in Content Studio for all 8 layouts
- [ ] Verify checking article-width constrains content to 600px
- [ ] Verify existing layout options (background, padding, border, fullwidth) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)