### PR TITLE
fix: add missing logger import to ButtonProcessor (closes #168)

### DIFF
--- a/src/main/resources/react4xp/parts/Button/ButtonProcessor.ts
+++ b/src/main/resources/react4xp/parts/Button/ButtonProcessor.ts
@@ -2,7 +2,8 @@ import type {ComponentProcessor} from '@enonic-types/lib-react4xp/DataFetcher';
 import type {NestedRecord, PartComponent} from '@enonic-types/core';
 import {get as getContent} from '/lib/xp/content';
 import {pageUrl} from '/lib/xp/portal';
-import { type ButtonProps } from '/react4xp/common/Button/ButtonProps';
+import {type ButtonProps} from '/react4xp/common/Button/ButtonProps';
+import {logger} from '/react4xp/utils/logger';
 
 /**
  * Button part configuration matching button.xml schema
@@ -97,7 +98,7 @@ export const buttonProcessor: ComponentProcessor<'lib.no:button'> = ({component}
           config?.urlSelector?.extern?.target
         ];
       } catch (error) {
-        log.error('Error creating URL:', error);
+        logger.error('Error creating URL:', error);
 
         return [undefined, undefined];
       }
@@ -113,7 +114,7 @@ export const buttonProcessor: ComponentProcessor<'lib.no:button'> = ({component}
     } as ButtonProps;
   }
   catch (error) {
-    log.error('Error in buttonProcessor:', error);
+    logger.error('Error in buttonProcessor:', error);
 
     return {
       title: 'Error',


### PR DESCRIPTION
## Summary

- Adds missing `logger` import to `ButtonProcessor.ts`
- Replaces two undefined `log.error()` calls with `logger.error()` using the project's centralized logging utility

## Problem

`ButtonProcessor` called `log.error()` in two `catch` blocks, but `log` was never imported. This caused a `ReferenceError` at runtime whenever an error occurred in URL building or the outer processor logic — hiding the original error entirely.

## Test plan

- [ ] Verify `npm run check:types:react4xp` passes without new errors
- [ ] Confirm Button parts render correctly in Storybook
- [ ] Test a Button part with an invalid content key to trigger the catch block and confirm the error is logged cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)