### PR TITLE
chore: resolve 14 ESLint warnings (closes #188)

### DIFF
--- a/src/main/resources/react4xp/common/DynamicLoader/DynamicLoader.tsx
+++ b/src/main/resources/react4xp/common/DynamicLoader/DynamicLoader.tsx
@@ -1,4 +1,4 @@
-import {type FC, type ReactNode, useEffect, useState} from 'react';
+import {type FC, type ReactNode, useState} from 'react';
 
 import doGuillotineRequest from '@utils/guillotine/request';
 
@@ -105,11 +105,7 @@ export const DynamicLoader: FC<DynamicLoaderProps> = ({
   const [list, setList] = useState<DynamicLoaderItem[]>(items);
   const [more, setMore] = useState(loadMoreEnabled && !!apiUrl && items.length === count);
   const [loading, setLoading] = useState(false);
-  const [nextOffset, setNextOffset] = useState(items.length);
-
-  useEffect(() => {
-    setNextOffset(list.length);
-  }, [list]);
+  const nextOffset = list.length;
 
   const updateItems = (data: DynamicLoaderItem[]): void => {
     if (data.length > 0) {

--- a/src/main/resources/react4xp/common/Footer/Footer.tsx
+++ b/src/main/resources/react4xp/common/Footer/Footer.tsx
@@ -67,8 +67,8 @@ export const Footer = ({
     <div className="footer-menu flex border border-[#F4F4F4] -mx-px min-h-[60px] px-5 items-center justify-center content-center mobile:flex-col">
       {some.length > 0 && (
         <div className="social-icons flex items-center text-[23px] gap-[10px] leading-[23px] absolute pl-5 left-0 mobile:justify-center mobile:pl-0 mobile:static">
-          {some.map((social, index) => (
-            <a key={index} href={social.href} rel="noreferrer" className="bg-background-700 text-[#63678A] no-underline">
+          {some.map((social) => (
+            <a key={social.href} href={social.href} rel="noreferrer" className="bg-background-700 text-[#63678A] no-underline">
               <i className={`fab ${social.className} text-center min-w-[24px] min-h-[24px]`}></i>
             </a>
           ))}

--- a/src/main/resources/react4xp/common/LocalBlock/LocalBlock.tsx
+++ b/src/main/resources/react4xp/common/LocalBlock/LocalBlock.tsx
@@ -89,9 +89,9 @@ export const LocalBlock: FC<LocalBlockProps> = ({
             'font-black leading-[1.2]',
             titleClassName === 'full' ? 'text-[5vw] mobile:text-[9vw]' : 'text-[3vw] mobile:text-[6vw]'
           )}>
-            {title.map((item, index) => (
+            {title.map((item) => (
               <span
-                key={index}
+                key={item.title}
                 className={cx(
                   'block',
                   item.titleColor === 'light' && 'text-button-100',

--- a/src/main/resources/react4xp/common/Map/Map.tsx
+++ b/src/main/resources/react4xp/common/Map/Map.tsx
@@ -75,13 +75,11 @@ export const Map: FC<MapProps> = ({
   position = [58.2953903, 6.6580986]
 }) => {
   const [pos, setPos] = useState<[number, number]>(position as [number, number]);
-  const [isSsr, setIsSsr] = useState(true);
+  const isSsr = typeof window === 'undefined';
   const [hasError, setHasError] = useState(false);
   const [leafletComponents, setLeafletComponents] = useState<LeafletComponents | null>(null);
 
   useEffect(() => {
-    setIsSsr(false);
-
     // Dynamically import react-leaflet to avoid bundling it in vendors.js
     // @ts-expect-error - Dynamic imports supported at runtime but not in ES2015 module setting
     import('react-leaflet').then((module: LeafletComponents) => {

--- a/src/main/resources/react4xp/common/MapLoader/MapLoader.tsx
+++ b/src/main/resources/react4xp/common/MapLoader/MapLoader.tsx
@@ -48,7 +48,9 @@ export const MapLoader: FC<MapLoaderProps> = ({
   position = [58.2953903, 6.6580986]
 }) => {
   const [MapComponent, setMapComponent] = useState<ComponentType<MapProps> | null>(null);
-  const [leafletLoaded, setLeafletLoaded] = useState(false);
+  const [leafletLoaded, setLeafletLoaded] = useState(
+    () => typeof window !== 'undefined' && !!document.getElementById('leaflet-css')
+  );
 
   useEffect(() => {
     // Load Leaflet CSS and JS if not already loaded
@@ -68,8 +70,6 @@ export const MapLoader: FC<MapLoaderProps> = ({
       script.crossOrigin = '';
       script.onload = () => setLeafletLoaded(true);
       document.head.appendChild(script);
-    } else if (typeof window !== 'undefined') {
-      setLeafletLoaded(true);
     }
   }, []);
 

--- a/src/main/resources/react4xp/common/Menu/Menu.tsx
+++ b/src/main/resources/react4xp/common/Menu/Menu.tsx
@@ -45,8 +45,8 @@ export const Menu = ({ menu }: MenuProps ) => {
           </label>
           <div className="overlay mobile:h-[110vh] mobile:w-screen mobile:bg-menu-bg mobile:z-20 mobile:invisible mobile:fixed mobile:left-0 mobile:top-0 peer-checked:visible">
             <ul className="main-menu flex list-none p-0 mobile:flex-col mobile:justify-center mobile:items-center mobile:text-center mobile:h-screen" aria-label={menu.ariaLabel}>
-              {menu.menuItems.map((menuItem, index) => (
-                <li key={index} className="mobile:p-4">
+              {menu.menuItems.map((menuItem) => (
+                <li key={menuItem.url} className="mobile:p-4">
                   <a
                     href={menuItem.url}
                     title={menuItem.title}

--- a/src/main/resources/react4xp/common/ProgrammeSection/ProgrammeSection.tsx
+++ b/src/main/resources/react4xp/common/ProgrammeSection/ProgrammeSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type FC} from 'react';
+import {type FC} from 'react';
 import slugify from 'react-slugify';
 
 import {Conclusions} from '/react4xp/common/Conclusions/Conclusions';

--- a/src/stories/layouts/LayoutWrappers.tsx
+++ b/src/stories/layouts/LayoutWrappers.tsx
@@ -23,7 +23,8 @@ export const TwoColumnWrapper: React.FC<TwoColumnProps> = ({
   rightClassName = 'one',
   children
 }) => {
-  const [first, second] = React.Children.toArray(children);
+  const slots = Array.isArray(children) ? children : [children];
+  const [first, second] = slots;
 
   return (
     <main>
@@ -62,7 +63,8 @@ export const ThreeColumnWrapper: React.FC<ThreeColumnProps> = ({
   rightClassName = 'one-33',
   children
 }) => {
-  const [first, second, third] = React.Children.toArray(children);
+  const slots = Array.isArray(children) ? children : [children];
+  const [first, second, third] = slots;
 
   return (
     <main>
@@ -106,7 +108,8 @@ export const FourColumnWrapper: React.FC<FourColumnProps> = ({
   rightClassName = 'one-25',
   children
 }) => {
-  const [first, second, third, fourth] = React.Children.toArray(children);
+  const slots = Array.isArray(children) ? children : [children];
+  const [first, second, third, fourth] = slots;
 
   return (
     <main>
@@ -155,7 +158,8 @@ export const TwoColumn2RowWrapper: React.FC<TwoColumn2RowProps> = ({
   order = '',
   children
 }) => {
-  const [first, second, third] = React.Children.toArray(children);
+  const slots = Array.isArray(children) ? children : [children];
+  const [first, second, third] = slots;
 
   return (
     <main>

--- a/src/stories/parts/Card.stories.tsx
+++ b/src/stories/parts/Card.stories.tsx
@@ -1,5 +1,4 @@
 import preview from '../../../.storybook/preview'
-import type { StoryObj } from '@storybook/react-webpack5'
 import { Card } from '@common/Card/Card'
 
 const meta = preview.meta({
@@ -14,8 +13,6 @@ const meta = preview.meta({
     )
   ]
 })
-
-type Story = StoryObj<typeof meta>
 
 export const Default = meta.story({
   args: {

--- a/src/stories/shared/ArticleCard.stories.tsx
+++ b/src/stories/shared/ArticleCard.stories.tsx
@@ -1,5 +1,4 @@
 import preview from '../../../.storybook/preview'
-import type { StoryObj } from '@storybook/react-webpack5'
 import { ArticleCard, type ItemData } from '@common/ArticleCard/ArticleCard'
 
 const meta = preview.meta({
@@ -16,8 +15,6 @@ const meta = preview.meta({
     )
   ]
 })
-
-type Story = StoryObj<typeof meta>
 
 const sampleItem: ItemData = {
   image: {

--- a/src/stories/shared/ArticleListItem.stories.tsx
+++ b/src/stories/shared/ArticleListItem.stories.tsx
@@ -1,5 +1,4 @@
 import preview from '../../../.storybook/preview'
-import type { StoryObj } from '@storybook/react-webpack5'
 import { ArticleListItem } from '@common/ArticleListItem/ArticleListItem'
 
 const meta = preview.meta({
@@ -14,8 +13,6 @@ const meta = preview.meta({
     )
   ]
 })
-
-type Story = StoryObj<typeof meta>
 
 export const Normal = meta.story({
   args: {


### PR DESCRIPTION
## Summary

Clears all 14 ESLint warnings — `npm run lint` now reports 0 problems.

### Changes by category

**`no-unused-vars` (4 warnings)**
- Remove unused `Fragment` import from `ProgrammeSection`
- Remove unused `Story` type and `StoryObj` import from `Card`, `ArticleCard` and `ArticleListItem` stories

**`no-array-index-key` (3 warnings)**
- `Footer` → use `social.href` as key
- `LocalBlock` → use `item.title` as key
- `Menu` → use `menuItem.url` as key

**`no-direct-set-state-in-use-effect` (3 warnings)**
- `DynamicLoader` → derive `nextOffset` from `list.length` instead of useState + useEffect
- `Map` → replace `useState(true)` + `setIsSsr(false)` in effect with a plain `const`
- `MapLoader` → initialise `leafletLoaded` lazily from the DOM to avoid synchronous setState

**`no-children-to-array` (4 warnings)**
- `LayoutWrappers` → replace all 4 `Children.toArray` calls with `Array.isArray(children) ? children : [children]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)