### PR TITLE
feat: improve BoardPresentation layout and spacing (closes #143)

### DIFF
--- a/src/main/resources/react4xp/common/BoardPresentation/BoardPresentation.tsx
+++ b/src/main/resources/react4xp/common/BoardPresentation/BoardPresentation.tsx
@@ -120,18 +120,19 @@ export const BoardPresentation: FC<BoardPresentationProps> = ({
             </div>
           )}
 
-          <div className="flex pl-[10px]">
-            <div className="flex flex-col gap-y-[6px] w-full">
+          <div className="members flex pl-[10px]">
+            <div className="members-inner flex flex-col gap-y-2 w-full">
               <div className="font-bold text-[22px] leading-[26px] text-primary-300">
                 {boardTitle}
               </div>
               {board.map(({itemId, role, name, email}) => (
-                <div key={itemId} className="flex flex-col text-[18px] leading-[22px] text-primary-300 w-full">
-                  <div className="flex w-full">
-                    <span className="font-medium w-[40%] after:content-[':_']">{role}</span><span className="w-[60%]">{name}</span>
+                <div key={itemId} className="member-item flex flex-col text-[18px] leading-[22px] text-primary-300 w-full">
+                  <div className="flex w-full gap-x-2">
+                    <span className="role font-semibold shrink-0">{role}:</span>
+                    <span className="name font-normal flex-1 break-words">{name}</span>
                   </div>
                   {showEmail === 'all' && email && (
-                    <div className="member-item-email mb-5">
+                    <div className="member-item-email">
                       <a href={`mailto:${email}`} rel="noreferrer">
                         {email}
                       </a>

--- a/src/stories/parts/BoardPresentation.stories.tsx
+++ b/src/stories/parts/BoardPresentation.stories.tsx
@@ -4,7 +4,20 @@ import { BoardPresentation } from '@common/BoardPresentation/BoardPresentation'
 const meta = preview.meta({
   title: 'Parts/BoardPresentation',
   component: BoardPresentation,
-  tags: ['autodocs']
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <main>
+        <div className="content-holder normal padding-bottom">
+          <div className="content">
+            <div className="content-item">
+              <Story />
+            </div>
+          </div>
+        </div>
+      </main>
+    )
+  ]
 })
 
 const boardMembers = [
@@ -115,5 +128,61 @@ export const SentralStyretHighlightingRight = meta.story({
   args: {
     ...SentralStyret.input.args,
     reverseOrder: true
+  }
+})
+
+const longNameMembers = [
+  {
+    itemId: 1,
+    name: 'Kristoffer Aleksander Johannessen-Haugen',
+    email: 'kristoffer@liberalistene.no',
+    role: 'Partileder',
+    image: {url: 'https://picsum.photos/200/200?random=10'}
+  },
+  {
+    itemId: 2,
+    name: 'Åsgård Ottervig',
+    email: 'asgard@liberalistene.no',
+    role: 'Webredaktør',
+    image: {url: 'https://picsum.photos/200/200?random=11'}
+  },
+  {
+    itemId: 3,
+    name: 'Sondre Thorvaldsen-Brekke',
+    email: 'sondre@liberalistene.no',
+    role: 'Organisatorisk Nestleder',
+    image: {url: 'https://picsum.photos/200/200?random=12'}
+  },
+  {
+    itemId: 4,
+    name: 'Li',
+    email: 'li@liberalistene.no',
+    role: 'Sekretær',
+    image: {url: 'https://picsum.photos/200/200?random=13'}
+  }
+]
+
+export const LongNamesHighlighted = meta.story({
+  args: {
+    title: 'Edge Case: Long Names',
+    boardTitle: 'Styre',
+    showEmail: 'no',
+    board: longNameMembers,
+    imagesize: 'medium',
+    imagetype: 'round'
+  }
+})
+
+export const LongNamesNoHighlighting = meta.story({
+  args: {
+    ...LongNamesHighlighted.input.args,
+    noHighlighting: true
+  }
+})
+
+export const LongNamesEmailAll = meta.story({
+  args: {
+    ...LongNamesHighlighted.input.args,
+    showEmail: 'all'
   }
 })


### PR DESCRIPTION
## Summary

- Add missing CSS class names (`members`, `members-inner`, `member-item`, `role`, `name`) so mobile responsive selectors target actual DOM nodes
- Replace fixed 40%/60% column widths with `shrink-0`/`flex-1` so long role names like "Varastyremedlem" no longer collide with the name
- Replace unreliable `after:content-[':_']` with inline colon and `gap-x-2` for consistent role/name spacing
- Bump role weight to `font-semibold`, name to `font-normal` for visual hierarchy
- Set row gap to 8px (`gap-y-2`) and remove stale `mb-5` from email div
- Add `content-holder` wrapper decorator to match `Board.stories` layout
- Add edge-case stories with long names and roles for visual testing

## Test plan

- [ ] Check `SentralStyret` story — role/name columns align cleanly
- [ ] Check `SentralStyretEmailAll` story — email spacing consistent with non-email entries
- [ ] Check `LongNamesHighlighted` story — long roles like "Organisatorisk Nestleder" don't overflow
- [ ] Check `LongNamesNoHighlighting` story — simple list mode with long names wraps correctly
- [ ] Verify mobile viewport — responsive selectors now target correct DOM nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)