### PR TITLE
chore: remove stale path aliases from tsconfig.storybook.json (closes #195)

### DIFF
--- a/tsconfig.storybook.json
+++ b/tsconfig.storybook.json
@@ -7,14 +7,6 @@
 	],
 	"compilerOptions": {
 		"jsx": "react-jsx",
-		"allowUmdGlobalAccess": false,
-		"paths": {
-			"@components/*": ["./src/main/resources/react4xp/components/*"],
-			"@common/*": ["./src/main/resources/react4xp/components/common/*"],
-			"@parts/*": ["./src/main/resources/react4xp/components/parts/*"],
-			"@layouts/*": ["./src/main/resources/react4xp/components/layouts/*"],
-			"@pages/*": ["./src/main/resources/react4xp/components/pages/*"],
-			"@lib/*": ["./src/main/resources/lib/*"]
-		}
+		"allowUmdGlobalAccess": false
 	}
 }


### PR DESCRIPTION
## Summary

- Remove stale `paths` block from `tsconfig.storybook.json` that was overriding the correct aliases inherited from `tsconfig.react4xp.json`
- The stale paths pointed to a `components/` subdirectory that no longer exists, causing editors (Cursor, VS Code) to report false errors on valid `@common/*` imports
- No story files used any of the removed aliases — confirmed by grep

## Test plan

- [ ] Open a story file in Cursor/VS Code — `@common/*` imports should resolve without errors
- [ ] `npm run check:types` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)