### PR TITLE
fix: allow dependabot[bot] in Claude Dependabot Review workflow (closes #207)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: dependabot[bot]
           prompt: |
             Review this Dependabot dependency update PR:
 


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: dependabot[bot]` to the Claude Dependabot Review workflow so the action accepts PRs initiated by the Dependabot bot actor

## Test plan
- [ ] Verify Claude Dependabot Review runs successfully on an open Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)