### PR TITLE
chore: pass ANTHROPIC_API_KEY as env variable in Claude Dependabot Review workflow (closes #209)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Passes `ANTHROPIC_API_KEY` as an `env` variable on the step in addition to the `with` input, which is required for the action to pick it up correctly in Dependabot PR contexts

## Test plan
- [ ] Verify Claude Dependabot Review runs successfully on an open Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)