### PR TITLE
chore: add fetch-depth: 0 to checkout step in Claude Dependabot Review workflow (closes #211)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- Adds `fetch-depth: 0` to the `actions/checkout@v5` step to ensure the full git history is available, which may be required by the Claude Code action during initialization

## Test plan
- [ ] Verify Claude Dependabot Review runs successfully on an open Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)