### PR TITLE
chore: pin Claude model to claude-sonnet-4-6-default in both review workflows (closes #213)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
           allowed_bots: dependabot[bot]
           prompt: |
             Review this Dependabot dependency update PR:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}


### PR DESCRIPTION
## Summary
- Pins both Claude review workflows to `claude-sonnet-4-6-default` to fix AJV SDK crash caused by the default `claude-sonnet-4-5-20250929` model (see anthropics/claude-code-action#965)

## Test plan
- [ ] Verify Claude PR Review runs successfully on a PR
- [ ] Verify Claude Dependabot Review runs successfully on a Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)