### PR TITLE
chore: fix model configuration using claude_args in both review workflows (closes #215)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+          claude_args: --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
           allowed_bots: dependabot[bot]
           prompt: |
             Review this Dependabot dependency update PR:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+          claude_args: --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}


### PR DESCRIPTION
## Summary
- Replaces invalid `model` input with `claude_args: --model` in both Claude review workflows
- Model defaults to `claude-sonnet-4-6-default` but can be overridden via `ANTHROPIC_DEFAULT_MODEL` repository variable

## Test plan
- [ ] Verify no warnings about unexpected inputs in workflow runs
- [ ] Verify Claude PR Review runs successfully on a PR
- [ ] Verify Claude Dependabot Review runs successfully on a Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)