### PR TITLE
chore: fix Claude review workflows by pinning claude-code to v2.1.18

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Claude Code v2.1.18
+        run: |
+          sudo rm -f /usr/local/bin/claude
+          npm install -g @anthropic-ai/claude-code@2.1.18
+          CLAUDE_BIN=$(which claude)
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1
         env:
@@ -29,7 +36,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}
           allowed_bots: dependabot[bot]
           prompt: |
             Review this Dependabot dependency update PR:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,9 +23,16 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
 
     steps:
+      - name: Install Claude Code v2.1.18
+        run: |
+          sudo rm -f /usr/local/bin/claude
+          npm install -g @anthropic-ai/claude-code@2.1.18
+          CLAUDE_BIN=$(which claude)
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}


### PR DESCRIPTION
## Summary

- Pin Claude Code to v2.1.18 via an explicit install step before the action runs
- Replace `claude_args --model` with `path_to_claude_code_executable` pointing to the pinned install
- Avoids the AJV schema validation crash introduced in `claude-agent-sdk@0.2.27+`

## Root Cause

`claude-code-action@v1` ships with a broken SDK version. The AJV validator crashes during initialization when `claude_args` is present in the config, before any API call is made.

## Test plan

- [ ] Verify Claude Dependabot Review workflow runs successfully on a Dependabot PR
- [ ] Verify Claude PR Review workflow runs successfully on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #217