### PR TITLE
chore: upgrade claude-code-action to v1.0.66 and remove workarounds (closes #222)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -17,26 +17,11 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Install Claude Code v2.1.18
-        run: |
-          sudo rm -f /usr/local/bin/claude
-          npm install -g @anthropic-ai/claude-code@2.1.18
-          CLAUDE_BIN=$(which claude)
-          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
-
       - name: Claude Review Dependabot PR
-        uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        uses: anthropics/claude-code-action@v1.0.66
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}
           allowed_bots: dependabot[bot]
           prompt: |
             Review this Dependabot dependency update PR:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,16 +23,8 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
 
     steps:
-      - name: Install Claude Code v2.1.18
-        run: |
-          sudo rm -f /usr/local/bin/claude
-          npm install -g @anthropic-ai/claude-code@2.1.18
-          CLAUDE_BIN=$(which claude)
-          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
-
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.66
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}


### PR DESCRIPTION
## Summary

- Upgraded both Claude review workflows from static `@v1` tag (Aug 2025) to `v1.0.66`
- Removed `Install Claude Code v2.1.18` workaround step from both workflows
- Removed checkout step from `claude-dependabot.yml` (likely trigger for the AJV crash)

## Test plan

- [ ] Verify `Claude Dependabot Review` passes on next Dependabot PR
- [ ] Verify `Claude PR Review` continues to work on regular PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)