### PR TITLE
fix: restore checkout step and add failure debug dump (closes #225)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -17,6 +17,11 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1.0.66
         with:
@@ -36,3 +41,17 @@ jobs:
             - Risk level (Low/Medium/High)
             - Key changes
             - Action recommendation
+
+      - name: Dump claude debug info
+        if: failure()
+        run: |
+          echo "=== ~/.claude/ ==="
+          find ~/.claude/ -type f 2>/dev/null | while read f; do
+            echo "--- $f ---"
+            cat "$f"
+          done || echo "No ~/.claude dir"
+          echo "=== project .claude/ ==="
+          find .claude/ -type f 2>/dev/null | while read f; do
+            echo "--- $f ---"
+            cat "$f"
+          done || echo "No project .claude dir"


### PR DESCRIPTION
## Summary

- Restored `checkout` step to `claude-dependabot.yml` — required by `claude-code-action@v1.0.66` for git configuration
- Added `if: failure()` debug dump step that recursively cats all files in `~/.claude/` and project `.claude/` to help trace the AJV crash origin

## Test plan

- [ ] Verify `Claude Dependabot Review` no longer fails with `fatal: not in a git directory`
- [ ] If AJV crash persists, check the debug dump output to identify which file contains the `dependencies` keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)