### PR TITLE
fix: switch claude workflows to pull_request_target (closes #227)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -1,13 +1,14 @@
 name: Claude Dependabot Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: read
   id-token: write
 
 jobs:
@@ -18,8 +19,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Claude Review Dependabot PR
@@ -27,7 +29,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_bots: dependabot[bot]
+          claude_args: >-
+            --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+            --max-turns 5
+            --allowedTools "Read,Grep,Glob,Bash(gh:*),Bash(git:*),Bash(jq:*)"
           prompt: |
             Review this Dependabot dependency update PR:
 
@@ -43,7 +48,7 @@ jobs:
             - Action recommendation
 
       - name: Dump claude debug info
-        if: failure()
+        if: failure() && vars.CLAUDE_DEBUG == 'true'
         run: |
           echo "=== ~/.claude/ ==="
           find ~/.claude/ -type f 2>/dev/null | while read f; do

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: read
   id-token: write
 
 jobs:
@@ -28,3 +29,21 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: >-
+            --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
+            --max-turns 5
+            --allowedTools "Read,Grep,Glob,Bash(gh:*),Bash(git:*),Bash(jq:*)"
+
+      - name: Dump claude debug info
+        if: failure() && vars.CLAUDE_DEBUG == 'true'
+        run: |
+          echo "=== ~/.claude/ ==="
+          find ~/.claude/ -type f 2>/dev/null | while read f; do
+            echo "--- $f ---"
+            cat "$f"
+          done || echo "No ~/.claude dir"
+          echo "=== project .claude/ ==="
+          find .claude/ -type f 2>/dev/null | while read f; do
+            echo "--- $f ---"
+            cat "$f"
+          done || echo "No project .claude dir"


### PR DESCRIPTION
## Summary

- Switch `claude-dependabot.yml` to `pull_request_target` so secrets are available for Dependabot PRs without the `allowed_bots` workaround
- Add explicit PR head SHA ref to checkout so Claude sees the PR content
- Add `actions: read` permission to both workflows
- Pass model via `claude_args` with `ANTHROPIC_DEFAULT_MODEL` variable fallback to `claude-sonnet-4-6-default`
- Add `--max-turns 5` and restricted `--allowedTools` to both workflows
- Gate debug dump step behind `CLAUDE_DEBUG` variable in both workflows

## Test plan
- [ ] Verify Dependabot PR triggers the review workflow and Claude can post a comment
- [ ] Verify regular PR triggers the review workflow
- [ ] Verify `@claude` mention in a comment triggers the review workflow
- [ ] Verify debug dump does NOT run on failure unless `CLAUDE_DEBUG = true` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)