### PR TITLE
fix: switch claude workflows to OAuth token and add pr review trigger (closes #230)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1.0.66
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: dependabot[bot]
           claude_args: >-
             --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
             --max-turns 5

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
@@ -27,7 +29,7 @@ jobs:
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1.0.66
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >-
             --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}


### PR DESCRIPTION
## Summary

Follow-up to #227/#228.

- Switch auth from `anthropic_api_key` to `claude_code_oauth_token` in both workflows
- Restore `allowed_bots: dependabot[bot]` — the action has its own bot check independent of `pull_request_target`
- Add `pull_request_review: [submitted]` trigger to `claude-pr-review.yml`

## Test plan
- [ ] Verify Dependabot PR triggers review and Claude can post a comment
- [ ] Verify regular PR triggers review
- [ ] Verify `@claude` mention triggers review
- [ ] Verify PR review submission triggers review

🤖 Generated with [Claude Code](https://claude.com/claude-code)