### PR TITLE
fix: correct reviewer username capitalization in dependabot.yml (closes #221)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,9 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
     assignees:
-      - 'virtueme'
+      - 'VirtueMe'
     reviewers:
-      - 'virtueme'
+      - 'VirtueMe'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -16,9 +16,9 @@ updates:
       interval: 'monthly'
     open-pull-requests-limit: 5
     assignees:
-      - 'virtueme'
+      - 'VirtueMe'
     reviewers:
-      - 'virtueme'
+      - 'VirtueMe'
     # Packages managed manually during major upgrades
     ignore:
       - dependency-name: 'react'
@@ -52,6 +52,6 @@ updates:
       interval: 'monthly'
     open-pull-requests-limit: 5
     assignees:
-      - 'virtueme'
+      - 'VirtueMe'
     reviewers:
-      - 'virtueme'
+      - 'VirtueMe'


### PR DESCRIPTION
## Summary

- GitHub username is `VirtueMe` not `virtueme` — fixes reviewer assignment on all Dependabot PRs

## Test plan
- [ ] Verify next Dependabot PR has correct reviewer assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)