### PR TITLE
chore: auto-update CLAUDE.md version via semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,19 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "sed -i \"s/^version = .*/version = ${nextRelease.version}/\" gradle.properties && ./gradlew clean build -Penv=prod && echo 'RELEASE_BUILT=true' >> $GITHUB_ENV"
+          "prepareCmd": "sed -i \"s/^version = .*/version = ${nextRelease.version}/\" gradle.properties"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "sed -i \"s/^\\*\\*Current Version:\\*\\* .*/\\*\\*Current Version:\\*\\* ${nextRelease.version}/\" CLAUDE.md"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "./gradlew clean build -Penv=prod && echo 'RELEASE_BUILT=true' >> $GITHUB_ENV"
         }
       ],
       [
@@ -197,7 +209,8 @@
             "CHANGELOG.md",
             "package.json",
             "package-lock.json",
-            "gradle.properties"
+            "gradle.properties",
+            "CLAUDE.md"
           ]
         }
       ],


### PR DESCRIPTION
## Summary

- Splits the single chained `prepareCmd` into three separate `@semantic-release/exec` entries — one per concern (gradle.properties, CLAUDE.md, Gradle build)
- Adds `CLAUDE.md` to `@semantic-release/git` assets so the `**Current Version:**` line is automatically updated and committed on every release

## Test plan

- [ ] Verify next release updates `**Current Version:**` in `CLAUDE.md` correctly

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)