### PR TITLE
fix: add repository and PR context to Claude workflow prompts

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Claude Review Dependabot PR
         uses: anthropics/claude-code-action@v1.0.66
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,8 +35,11 @@ jobs:
           claude_args: >-
             --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
             --max-turns 5
-            --allowedTools "Read,Grep,Glob,Bash(gh:*),Bash(git:*),Bash(jq:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this Dependabot dependency update PR:
 
             1. Check the changelog and release notes for breaking changes

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,15 +26,27 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1.0.66
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for code quality, correctness, and adherence to project conventions.
           claude_args: >-
             --model ${{ vars.ANTHROPIC_DEFAULT_MODEL || 'claude-sonnet-4-6-default' }}
             --max-turns 5
-            --allowedTools "Read,Grep,Glob,Bash(gh:*),Bash(git:*),Bash(jq:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Dump claude debug info
         if: failure() && vars.CLAUDE_DEBUG == 'true'


### PR DESCRIPTION
## Summary

- Added required `REPO` and `PR NUMBER` context to both Claude workflow prompts (documented requirement from the [v1.0 migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md))
- Added missing `actions/checkout` step to `claude-pr-review.yml` — Claude had no code to read
- Updated `allowedTools` in both workflows to use the correct MCP inline comment tool and scoped `gh` commands as per the [official examples](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml)

## Test plan

- [ ] Verify next Dependabot PR gets a proper review comment from Claude
- [ ] Verify `claude-pr-review.yml` can post inline comments on PRs

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)