### PR TITLE
fix: skip claude-pr-review for Dependabot PRs (closes #255)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -21,9 +21,11 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name == 'pull_request') ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      )
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Adds `github.actor != 'dependabot[bot]'` to the job `if` condition in `claude-pr-review.yml`
- Dependabot PRs are already reviewed by `claude-dependabot.yml` — no need for the general review to run too

## Test plan

- [ ] `claude-pr-review` is skipped on the next Dependabot PR
- [ ] `claude-dependabot-review` still runs on Dependabot PRs as before
- [ ] `claude-pr-review` still runs normally on human-authored PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)