### PR TITLE
chore: skip Codecov upload on Dependabot PRs (closes #258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]'` to the Codecov upload step in `ci.yml`
- Dependabot PRs only change dependencies — coverage is identical to master and adds noise to Codecov without value

## Test plan

- [ ] Codecov upload is skipped on the next Dependabot PR
- [ ] Codecov upload still runs on human-authored PRs and master pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)